### PR TITLE
Move Icons to the start of the line

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -36,16 +36,16 @@ pub struct Device {
 impl Device {
     pub fn get_icon(name: &str) -> String {
         match name {
-            "audio-card" => String::from("󰦢 "),
+            "audio-card" => String::from("󰓃"),
             "audio-input-microphone" => String::from(""),
-            "audio-headphones" => String::from("󰥰"),
-            "battery" => String::from("󰥆"),
+            "audio-headphones" => String::from("󰋋"),
+            "battery" => String::from("󰂀"),
             "camera-photo" => String::from("󰻛"),
             "computer" => String::from(""),
             "input-keyboard" => String::from("󰌌"),
-            "input-mouse" => String::from("󰦋"),
-            "phone" => String::from("󰏳"),
-            _ => String::new(),
+            "input-mouse" => String::from("󰍽"),
+            "phone" => String::from("󰏲"),
+            _ => String::from("?"),
         }
     }
 }
@@ -103,7 +103,7 @@ impl Controller {
 
             let device = Device {
                 addr,
-                alias: format!("{} {}", alias, icon),
+                alias: format!("{} {}", icon, alias),
                 is_paired,
                 is_trusted,
                 is_connected,
@@ -116,6 +116,7 @@ impl Controller {
                 new_devices.push(device);
             }
         }
+
         paired_devices.sort_by_key(|i| i.addr);
         new_devices.sort_by_key(|i| i.addr);
         Ok((paired_devices, new_devices))

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -45,7 +45,7 @@ impl Device {
             "input-keyboard" => String::from("󰌌"),
             "input-mouse" => String::from("󰍽"),
             "phone" => String::from("󰏲"),
-            _ => String::from("?"),
+            _ => String::from(" "),
         }
     }
 }


### PR DESCRIPTION
This is a small subjective change, but i think that the icons being at the start looks better, also the bluetooth indicator has been removed as this being a bluetooth manager already implies that those are bluetooth devices, removing it makes it look less cluttered.

Before:
![image](https://github.com/pythops/bluetui/assets/97509031/cc99d3a4-8047-426c-b72e-5f7c42d47043)

After:
![image](https://github.com/pythops/bluetui/assets/97509031/fbf1635a-620a-4e24-b375-10ad503f0ed3)
