### PR TITLE
Add installation instruction for Gentoo Linux distro

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,16 @@ You can install `bluetui` from the [AUR](https://aur.archlinux.org/packages/blue
 paru -S bluetui
 ```
 
+### 🐧 Gentoo
+
+You can install `bluetui` from the [lamdness Gentoo Overlay](https://gpo.zugaina.org/net-wireless/bluetui):
+```sh
+sudo eselect repository enable lamdness
+sudo emaint -r lamdness sync
+sudo emerge -av net-wireless/bluetui
+```
+
+
 ### ⚒️ Build from source
 
 Run the following command:


### PR DESCRIPTION
Thanks for this application, works like a charm on my new Framework 13 Ryzen laptop.

I've added a Gentoo ebuild for bluetui into my own overlay that is available in the official Gentoo overlay list so users can easily enable it.
