### PR TITLE
Added x install Support for bluetui

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,14 @@ sudo emaint -r lamdness sync
 sudo emerge -av net-wireless/bluetui
 ```
 
+### 🧰 X-CMD
+
+If you are a user of [x-cmd](https://x-cmd.com), you can run:
+
+```shell
+x install bluetui
+```
+
 
 ### ⚒️ Build from source
 


### PR DESCRIPTION
Hi there,

I've updated the README to include x install from the x-cmd ecosystem, making bluetui installation easier across different platforms and package managers.

I've also created an introduction page:
👉 https://x-cmd.com/install/bluetui

Hope this helps! Let me know if any changes are needed.

Thanks!