### PR TITLE
Add icon support for audio-headset devices

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -48,7 +48,7 @@ impl Device {
         match name {
             "audio-card" => Some(String::from("󰓃")),
             "audio-input-microphone" => Some(String::from("")),
-            "audio-headphones" => Some(String::from("󰋋")),
+            "audio-headphones" | "audio-headset" => Some(String::from("󰋋")),
             "battery" => Some(String::from("󰂀")),
             "camera-photo" => Some(String::from("󰻛")),
             "computer" => Some(String::from("")),


### PR DESCRIPTION
Huawei Earbuds report the device type as 'audio-headset'. This PR adds icon support for this type by extending the corresponding arm in `src/bluetooth.rs:Device::get_icon()`. I have tested this commit and it correctly shows the icon for the Huawei FreeBuds 5i.