### PR TITLE
add: fuzzy search through scan output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "crossterm 0.29.0",
  "dirs",
  "futures",
+ "fuzzy-matcher",
  "ratatui 0.29.0",
  "serde",
  "tokio",
@@ -772,6 +773,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1895,6 +1905,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bluer = { version = "0.17", features = ["full"] }
 crossterm = { version = "0.29", default-features = false, features = [
     "event-stream",
 ] }
+fuzzy-matcher = "0.3"
 futures = "0.3"
 ratatui = "0.29"
 tokio = { version = "1", features = ["full"] }

--- a/Readme.md
+++ b/Readme.md
@@ -99,6 +99,13 @@ This will produce an executable file at `target/release/bluetui` that you can co
 
 ### New devices
 
+`/`: Fuzzy search devices. In search mode:
+  - All devices shown initially (start typing to filter)
+  - Type any characters to filter devices in real-time (including 'j' and 'k')
+  - `↑/↓`: Navigate through results (arrow keys only)
+  - `Enter` or `Space`: Pair with selected device
+  - `Esc`: Exit search with selected device highlighted
+
 `Space or Enter`: Pair the device.
 
 ## Config
@@ -121,10 +128,13 @@ toggle_pairing = "p"
 toggle_power = "o"
 toggle_discovery = "d"
 
-[paired_device]
-unpair = "u"
-toggle_trust = "t"
-rename = "e"
+ [paired_device]
+ unpair = "u"
+ toggle_trust = "t"
+ rename = "e"
+
+ [new_devices]
+ search = "/"
 ```
 
 ## 🎁 Note

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
 
     #[serde(default)]
     pub paired_device: PairedDevice,
+
+    #[serde(default)]
+    pub new_devices: NewDevices,
 }
 
 #[derive(Debug, Default)]
@@ -134,6 +137,20 @@ impl Default for PairedDevice {
     }
 }
 
+#[derive(Deserialize, Debug)]
+pub struct NewDevices {
+    #[serde(default = "default_search_new_devices")]
+    pub search: char,
+}
+
+impl Default for NewDevices {
+    fn default() -> Self {
+        Self {
+            search: '/',
+        }
+    }
+}
+
 fn deserialize_layout<'de, D>(deserializer: D) -> Result<Flex, D::Error>
 where
     D: Deserializer<'de>,
@@ -191,6 +208,10 @@ fn default_unpair_device() -> char {
 
 fn default_toggle_device_trust() -> char {
     't'
+}
+
+fn default_search_new_devices() -> char {
+    '/'
 }
 
 impl Config {

--- a/src/help.rs
+++ b/src/help.rs
@@ -180,6 +180,22 @@ impl Help {
                     Span::from(" Discard"),
                 ])]
             }
+            FocusedBlock::SearchNewDevices => vec![Line::from(vec![
+                Span::from("k,").bold(),
+                Span::from("  Up"),
+                Span::from(" | "),
+                Span::from("j,").bold(),
+                Span::from("  Down"),
+                Span::from(" | "),
+                Span::from("󱁐  or ↵ ").bold(),
+                Span::from(" Pair"),
+                Span::from(" | "),
+                Span::from("󱊷 ").bold(),
+                Span::from(" Exit search"),
+                Span::from(" | "),
+                Span::from("⇄").bold(),
+                Span::from(" Nav"),
+            ])],
         };
         let help = Paragraph::new(help).centered().blue();
         frame.render_widget(help, rendering_block);


### PR DESCRIPTION
this is my local branch I've been using to search through large scan output (if you are in an airport, or busy bluetooth area)

the default keybinding is `/` if you are in scan panel and then can start typing to find your bluetooth device for pairing or connecting.