### PR TITLE
fix(nix): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752115281,
-        "narHash": "sha256-3i0sUli3sWCglfpj+yS1gtA+4m2ao2UMIxa4IfifUUU=",
+        "lastModified": 1767754000,
+        "narHash": "sha256-znoNJs2QZFl+wCFLd6FbUJ00c74kvzOjyQYXc45uFvo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e5b68250e585c60d1679803045575fb71801d822",
+        "rev": "0b3a5ad260479f2c9bdadf3ba5b2a4be359cfcdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The packages exposed by the `flake.nix` file were broken and didn't compile. Caused by a rustc version that was too old (1.87). This PR fixes that by updating the flake inputs.

(Btw, I work for [garnix.io](https://garnix.io). Garnix provides CI services for repos with `flake.nix` files based on nix and integrated with github. You can see the CI runs for my fork [here on garnix.io](https://app.garnix.io/repo/soenkehahn/bluetui) and [here on github](https://github.com/soenkehahn/bluetui/runs/59734320137). It has a free tier. Sorry about the sales pitch! Let me know if you're interested in setting that up for this repo. Otherwise, please ignore!)
