### PR TITLE
Add customizable navigation keybindings.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -178,7 +178,7 @@ help_text = "blue"
 
 ## 🎁 Note
 
-If you like `bluetui` and you are looking for a TUI to manage WiFi, checkout out [impala](https://github.com/pythops/impala)
+If you like `bluetui` and you are looking for a TUI to manage WiFi, checkout out [impala](https://github.com/pythops/impala) or [netpala](https://github.com/joel-sgc/netpala)
 
 ## ⚖️ License
 

--- a/Readme.md
+++ b/Readme.md
@@ -124,6 +124,14 @@ unpair = "u"
 toggle_trust = "t"
 toggle_favorite = "f"
 rename = "e"
+
+[navigation]
+up = "k"
+down = "j"
+left = "h"
+right = "l"
+quit = "q"
+select = " "  # Space key for connect/disconnect/pair
 ```
 
 ## Contributing

--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,42 @@ left = "h"
 right = "l"
 quit = "q"
 select = " "  # Space key for connect/disconnect/pair
+
+[colors]
+# Colors can be specified as named colors or hex values (#RRGGBB)
+# Named colors: black, red, green, yellow, blue, magenta, cyan, gray, dark_gray,
+#               light_red, light_green, light_yellow, light_blue, light_magenta,
+#               light_cyan, white, reset
+
+# Border color when a section is focused
+focused_border = "green"
+
+# Border color when a section is not focused
+unfocused_border = "reset"
+
+# Header text color in focused tables
+focused_header = "yellow"
+
+# Background color for selected items
+highlight_bg = "dark_gray"
+
+# Text color for selected items
+highlight_fg = "white"
+
+# Color for informational messages
+info = "green"
+
+# Color for warning messages
+warning = "yellow"
+
+# Color for error messages
+error = "red"
+
+# Color for the scanning spinner
+spinner = "blue"
+
+# Color for the help text at the bottom of the window
+help_text = "blue"
 ```
 
 ## Contributing

--- a/examples/config_simple_colors.toml
+++ b/examples/config_simple_colors.toml
@@ -1,0 +1,65 @@
+# Example bluetui configuration with simple named colors
+
+# Layout configuration
+layout = "SpaceAround"
+width = "auto"
+
+# Global keybindings
+toggle_scanning = "s"
+esc_quit = false
+
+# Adapter keybindings
+[adapter]
+toggle_pairing = "p"
+toggle_power = "o"
+toggle_discovery = "d"
+
+# Paired device keybindings
+[paired_device]
+unpair = "u"
+toggle_trust = "t"
+toggle_favorite = "f"
+rename = "e"
+
+# Navigation keybindings
+[navigation]
+up = "k"
+down = "j"
+left = "h"
+right = "l"
+quit = "q"
+select = " "
+
+# Simple color scheme using named colors
+[colors]
+# Available named colors:
+# black, red, green, yellow, blue, magenta, cyan, gray, dark_gray,
+# light_red, light_green, light_yellow, light_blue, light_magenta,
+# light_cyan, white, reset
+
+# Border color when a section is focused
+focused_border = "light_cyan"
+
+# Border color when a section is not focused
+unfocused_border = "dark_gray"
+
+# Header text color in focused tables
+focused_header = "light_yellow"
+
+# Background color for selected items
+highlight_bg = "blue"
+
+# Text color for selected items
+highlight_fg = "white"
+
+# Color for informational messages
+info = "light_green"
+
+# Color for warning messages
+warning = "yellow"
+
+# Color for error messages
+error = "light_red"
+
+# Color for the scanning spinner
+spinner = "cyan"

--- a/examples/config_with_colors.toml
+++ b/examples/config_with_colors.toml
@@ -1,0 +1,110 @@
+# Example bluetui configuration with custom color scheme
+
+# Layout configuration
+layout = "SpaceAround"
+width = "auto"
+
+# Global keybindings
+toggle_scanning = "s"
+esc_quit = false
+
+# Adapter keybindings
+[adapter]
+toggle_pairing = "p"
+toggle_power = "o"
+toggle_discovery = "d"
+
+# Paired device keybindings
+[paired_device]
+unpair = "u"
+toggle_trust = "t"
+toggle_favorite = "f"
+rename = "e"
+
+# Navigation keybindings
+[navigation]
+up = "k"
+down = "j"
+left = "h"
+right = "l"
+quit = "q"
+select = " "
+
+# Custom color scheme - Dracula theme inspired
+[colors]
+# Border color when a section is focused
+focused_border = "#bd93f9"  # Purple
+
+# Border color when a section is not focused
+unfocused_border = "#44475a"  # Dark gray
+
+# Header text color in focused tables
+focused_header = "#f1fa8c"  # Yellow
+
+# Background color for selected items
+highlight_bg = "#44475a"  # Dark gray
+
+# Text color for selected items
+highlight_fg = "#f8f8f2"  # Light gray
+
+# Color for informational messages
+info = "#50fa7b"  # Green
+
+# Color for warning messages
+warning = "#ffb86c"  # Orange
+
+# Color for error messages
+error = "#ff5555"  # Red
+
+# Color for the scanning spinner
+spinner = "#8be9fd"  # Cyan
+
+# Alternative color schemes you can try:
+
+# Solarized Dark
+# [colors]
+# focused_border = "#268bd2"
+# unfocused_border = "#073642"
+# focused_header = "#b58900"
+# highlight_bg = "#073642"
+# highlight_fg = "#839496"
+# info = "#859900"
+# warning = "#cb4b16"
+# error = "#dc322f"
+# spinner = "#2aa198"
+
+# Gruvbox Dark
+# [colors]
+# focused_border = "#fabd2f"
+# unfocused_border = "#3c3836"
+# focused_header = "#fabd2f"
+# highlight_bg = "#3c3836"
+# highlight_fg = "#ebdbb2"
+# info = "#b8bb26"
+# warning = "#fe8019"
+# error = "#fb4934"
+# spinner = "#83a598"
+
+# Nord
+# [colors]
+# focused_border = "#88c0d0"
+# unfocused_border = "#3b4252"
+# focused_header = "#ebcb8b"
+# highlight_bg = "#3b4252"
+# highlight_fg = "#eceff4"
+# info = "#a3be8c"
+# warning = "#d08770"
+# error = "#bf616a"
+# spinner = "#5e81ac"
+
+# High Contrast
+# [colors]
+# focused_border = "white"
+# unfocused_border = "dark_gray"
+# focused_header = "light_yellow"
+# highlight_bg = "blue"
+# highlight_fg = "white"
+# info = "light_green"
+# warning = "yellow"
+# error = "light_red"
+# spinner = "light_cyan"

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use futures::FutureExt;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Margin, Rect},
-    style::{Color, Modifier, Style, Stylize},
+    style::{Modifier, Style, Stylize},
     text::{Line, Span},
     widgets::{
         Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Scrollbar,
@@ -233,8 +233,8 @@ impl App {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .style(Style::default().green())
-                .border_style(Style::default().fg(Color::Green)),
+                .style(Style::default().fg(self.config.colors.focused_border))
+                .border_style(Style::default().fg(self.config.colors.focused_border)),
             block,
         );
 
@@ -253,15 +253,15 @@ impl App {
 
                 let msg = Paragraph::new(text)
                     .alignment(Alignment::Center)
-                    .style(Style::default().fg(Color::White))
+                    .style(Style::default().fg(self.config.colors.highlight_fg))
                     .block(Block::new().padding(Padding::horizontal(2)));
 
                 let alias = Paragraph::new(self.new_alias.value())
                     .alignment(Alignment::Left)
-                    .style(Style::default().fg(Color::White))
+                    .style(Style::default().fg(self.config.colors.highlight_fg))
                     .block(
                         Block::new()
-                            .bg(Color::DarkGray)
+                            .bg(self.config.colors.highlight_bg)
                             .padding(Padding::horizontal(2)),
                     );
 
@@ -343,11 +343,11 @@ impl App {
                 .header({
                     if self.focused_block == FocusedBlock::Adapter {
                         Row::new(vec![
-                            Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Alias").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Power").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Pairable").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Discoverable").style(Style::default().fg(Color::Yellow)),
+                            Cell::from("Name").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Alias").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Power").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Pairable").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Discoverable").style(Style::default().fg(self.config.colors.focused_header)),
                         ])
                         .style(Style::new().bold())
                         .bottom_margin(1)
@@ -375,9 +375,9 @@ impl App {
                         .borders(Borders::ALL)
                         .border_style({
                             if self.focused_block == FocusedBlock::Adapter {
-                                Style::default().fg(Color::Green)
+                                Style::default().fg(self.config.colors.focused_border)
                             } else {
-                                Style::default()
+                                Style::default().fg(self.config.colors.unfocused_border)
                             }
                         })
                         .border_type({
@@ -390,7 +390,7 @@ impl App {
                 )
                 .flex(self.config.layout)
                 .row_highlight_style(if self.focused_block == FocusedBlock::Adapter {
-                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                    Style::default().bg(self.config.colors.highlight_bg).fg(self.config.colors.highlight_fg)
                 } else {
                     Style::default()
                 });
@@ -502,11 +502,11 @@ impl App {
                     if show_battery_column {
                         if self.focused_block == FocusedBlock::PairedDevices {
                             Row::new(vec![
-                                Cell::from("").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Battery").style(Style::default().fg(Color::Yellow)),
+                                Cell::from("").style(Style::default().fg(self.config.colors.focused_header)),
+                                Cell::from("Name").style(Style::default().fg(self.config.colors.focused_header)),
+                                Cell::from("Trusted").style(Style::default().fg(self.config.colors.focused_header)),
+                                Cell::from("Connected").style(Style::default().fg(self.config.colors.focused_header)),
+                                Cell::from("Battery").style(Style::default().fg(self.config.colors.focused_header)),
                             ])
                             .style(Style::new().bold())
                             .bottom_margin(1)
@@ -522,10 +522,10 @@ impl App {
                         }
                     } else if self.focused_block == FocusedBlock::PairedDevices {
                         Row::new(vec![
-                            Cell::from("").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
+                            Cell::from("").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Name").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Trusted").style(Style::default().fg(self.config.colors.focused_header)),
+                            Cell::from("Connected").style(Style::default().fg(self.config.colors.focused_header)),
                         ])
                         .style(Style::new().bold())
                         .bottom_margin(1)
@@ -553,9 +553,9 @@ impl App {
                         .borders(Borders::ALL)
                         .border_style({
                             if self.focused_block == FocusedBlock::PairedDevices {
-                                Style::default().fg(Color::Green)
+                                Style::default().fg(self.config.colors.focused_border)
                             } else {
-                                Style::default()
+                                Style::default().fg(self.config.colors.unfocused_border)
                             }
                         })
                         .border_type({
@@ -568,7 +568,7 @@ impl App {
                 )
                 .flex(self.config.layout)
                 .row_highlight_style(if self.focused_block == FocusedBlock::PairedDevices {
-                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                    Style::default().bg(self.config.colors.highlight_bg).fg(self.config.colors.highlight_fg)
                 } else {
                     Style::default()
                 });
@@ -616,8 +616,8 @@ impl App {
                     .header({
                         if self.focused_block == FocusedBlock::NewDevices {
                             Row::new(vec![
-                                Cell::from(Line::from("Address").fg(Color::Yellow).centered()),
-                                Cell::from(Line::from("Name").fg(Color::Yellow).centered()),
+                                Cell::from(Line::from("Address").fg(self.config.colors.focused_header).centered()),
+                                Cell::from(Line::from("Name").fg(self.config.colors.focused_header).centered()),
                             ])
                             .style(Style::new().bold())
                             .bottom_margin(1)
@@ -649,9 +649,9 @@ impl App {
                             .borders(Borders::ALL)
                             .border_style({
                                 if self.focused_block == FocusedBlock::NewDevices {
-                                    Style::default().fg(Color::Green)
+                                    Style::default().fg(self.config.colors.focused_border)
                                 } else {
-                                    Style::default()
+                                    Style::default().fg(self.config.colors.unfocused_border)
                                 }
                             })
                             .border_type({
@@ -664,7 +664,7 @@ impl App {
                     )
                     .flex(self.config.layout)
                     .row_highlight_style(if self.focused_block == FocusedBlock::NewDevices {
-                        Style::default().bg(Color::DarkGray).fg(Color::White)
+                        Style::default().bg(self.config.colors.highlight_bg).fg(self.config.colors.highlight_fg)
                     } else {
                         Style::default()
                     });
@@ -714,28 +714,28 @@ impl App {
 
             // Request Confirmation
             if let Some(req) = &self.requests.confirmation {
-                req.render(frame, area);
+                req.render(frame, area, self.config.clone());
             }
 
             // Request to enter pin code
 
             if let Some(req) = &self.requests.enter_pin_code {
-                req.render(frame, area);
+                req.render(frame, area, self.config.clone());
             }
 
             // Request passkey
             if let Some(req) = &self.requests.enter_passkey {
-                req.render(frame, area);
+                req.render(frame, area, self.config.clone());
             }
 
             // Display Pin Code
             if let Some(req) = &self.requests.display_pin_code {
-                req.render(frame, area);
+                req.render(frame, area, self.config.clone());
             }
 
             // Display Passkey
             if let Some(req) = &self.requests.display_passkey {
-                req.render(frame, area);
+                req.render(frame, area, self.config.clone());
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use serde::{
     Deserialize, Deserializer,
     de::{self, Unexpected, Visitor},
 };
+use ratatui::style::Color;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -32,6 +33,9 @@ pub struct Config {
 
     #[serde(default)]
     pub navigation: Navigation,
+
+    #[serde(default)]
+    pub colors: Colors,
 }
 
 #[derive(Debug, Default)]
@@ -260,6 +264,138 @@ fn default_quit() -> char {
 
 fn default_select() -> char {
     ' '
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Colors {
+    #[serde(default = "default_focused_border", deserialize_with = "deserialize_color")]
+    pub focused_border: Color,
+
+    #[serde(default = "default_unfocused_border", deserialize_with = "deserialize_color")]
+    pub unfocused_border: Color,
+
+    #[serde(default = "default_focused_header", deserialize_with = "deserialize_color")]
+    pub focused_header: Color,
+
+    #[serde(default = "default_highlight_bg", deserialize_with = "deserialize_color")]
+    pub highlight_bg: Color,
+
+    #[serde(default = "default_highlight_fg", deserialize_with = "deserialize_color")]
+    pub highlight_fg: Color,
+
+    #[serde(default = "default_info", deserialize_with = "deserialize_color")]
+    pub info: Color,
+
+    #[serde(default = "default_warning", deserialize_with = "deserialize_color")]
+    pub warning: Color,
+
+    #[serde(default = "default_error", deserialize_with = "deserialize_color")]
+    pub error: Color,
+
+    #[serde(default = "default_spinner", deserialize_with = "deserialize_color")]
+    pub spinner: Color,
+
+    #[serde(default = "default_help_text", deserialize_with = "deserialize_color")]
+    pub help_text: Color,
+}
+
+impl Default for Colors {
+    fn default() -> Self {
+        Self {
+            focused_border: Color::Green,
+            unfocused_border: Color::Reset,
+            focused_header: Color::Yellow,
+            highlight_bg: Color::DarkGray,
+            highlight_fg: Color::White,
+            info: Color::Green,
+            warning: Color::Yellow,
+            error: Color::Red,
+            spinner: Color::Blue,
+            help_text: Color::Blue,
+        }
+    }
+}
+
+fn deserialize_color<'de, D>(deserializer: D) -> Result<Color, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    
+    match s.to_lowercase().as_str() {
+        "reset" => Ok(Color::Reset),
+        "black" => Ok(Color::Black),
+        "red" => Ok(Color::Red),
+        "green" => Ok(Color::Green),
+        "yellow" => Ok(Color::Yellow),
+        "blue" => Ok(Color::Blue),
+        "magenta" => Ok(Color::Magenta),
+        "cyan" => Ok(Color::Cyan),
+        "gray" | "grey" => Ok(Color::Gray),
+        "darkgray" | "darkgrey" | "dark_gray" | "dark_grey" => Ok(Color::DarkGray),
+        "lightred" | "light_red" => Ok(Color::LightRed),
+        "lightgreen" | "light_green" => Ok(Color::LightGreen),
+        "lightyellow" | "light_yellow" => Ok(Color::LightYellow),
+        "lightblue" | "light_blue" => Ok(Color::LightBlue),
+        "lightmagenta" | "light_magenta" => Ok(Color::LightMagenta),
+        "lightcyan" | "light_cyan" => Ok(Color::LightCyan),
+        "white" => Ok(Color::White),
+        _ => {
+            // Try to parse as RGB hex color (#RRGGBB)
+            if let Some(hex) = s.strip_prefix('#') {
+                if hex.len() == 6 {
+                    if let Ok(r) = u8::from_str_radix(&hex[0..2], 16) {
+                        if let Ok(g) = u8::from_str_radix(&hex[2..4], 16) {
+                            if let Ok(b) = u8::from_str_radix(&hex[4..6], 16) {
+                                return Ok(Color::Rgb(r, g, b));
+                            }
+                        }
+                    }
+                }
+            }
+            Err(de::Error::custom(format!("Invalid color: {}. Use named colors (e.g., 'green', 'yellow') or hex format '#RRGGBB'", s)))
+        }
+    }
+}
+
+fn default_focused_border() -> Color {
+    Color::Green
+}
+
+fn default_unfocused_border() -> Color {
+    Color::Reset
+}
+
+fn default_focused_header() -> Color {
+    Color::Yellow
+}
+
+fn default_highlight_bg() -> Color {
+    Color::DarkGray
+}
+
+fn default_highlight_fg() -> Color {
+    Color::White
+}
+
+fn default_info() -> Color {
+    Color::Green
+}
+
+fn default_warning() -> Color {
+    Color::Yellow
+}
+
+fn default_error() -> Color {
+    Color::Red
+}
+
+fn default_spinner() -> Color {
+    Color::Blue
+}
+
+fn default_help_text() -> Color {
+    Color::Blue
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
 
     #[serde(default)]
     pub paired_device: PairedDevice,
+
+    #[serde(default)]
+    pub navigation: Navigation,
 }
 
 #[derive(Debug, Default)]
@@ -138,6 +141,40 @@ impl Default for PairedDevice {
     }
 }
 
+#[derive(Deserialize, Debug)]
+pub struct Navigation {
+    #[serde(default = "default_nav_up")]
+    pub up: char,
+
+    #[serde(default = "default_nav_down")]
+    pub down: char,
+
+    #[serde(default = "default_nav_left")]
+    pub left: char,
+
+    #[serde(default = "default_nav_right")]
+    pub right: char,
+
+    #[serde(default = "default_quit")]
+    pub quit: char,
+
+    #[serde(default = "default_select")]
+    pub select: char,
+}
+
+impl Default for Navigation {
+    fn default() -> Self {
+        Self {
+            up: 'k',
+            down: 'j',
+            left: 'h',
+            right: 'l',
+            quit: 'q',
+            select: ' ',
+        }
+    }
+}
+
 fn deserialize_layout<'de, D>(deserializer: D) -> Result<Flex, D::Error>
 where
     D: Deserializer<'de>,
@@ -199,6 +236,30 @@ fn default_toggle_device_trust() -> char {
 
 fn default_toggle_device_favorite() -> char {
     'f'
+}
+
+fn default_nav_up() -> char {
+    'k'
+}
+
+fn default_nav_down() -> char {
+    'j'
+}
+
+fn default_nav_left() -> char {
+    'h'
+}
+
+fn default_nav_right() -> char {
+    'l'
+}
+
+fn default_quit() -> char {
+    'q'
+}
+
+fn default_select() -> char {
+    ' '
 }
 
 impl Config {

--- a/src/help.rs
+++ b/src/help.rs
@@ -197,7 +197,7 @@ impl Help {
                 ])]
             }
         };
-        let help = Paragraph::new(help).centered().blue();
+        let help = Paragraph::new(help).centered().fg(config.colors.help_text);
         frame.render_widget(help, rendering_block);
     }
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -20,17 +20,23 @@ impl Help {
         rendering_block: Rect,
         config: Arc<Config>,
     ) {
+        let nav_up = config.navigation.up.to_string();
+        let nav_down = config.navigation.down.to_string();
+        let toggle_scanning = config.toggle_scanning.to_string();
+
         let help = match focused_block {
             FocusedBlock::PairedDevices => {
                 if area.width > 120 {
                     vec![Line::from(vec![
-                        Span::from("k,").bold(),
+                        Span::from(nav_up.clone()).bold(),
+                        Span::from(",").bold(),
                         Span::from("  Up"),
                         Span::from(" | "),
-                        Span::from("j,").bold(),
+                        Span::from(nav_down.clone()).bold(),
+                        Span::from(",").bold(),
                         Span::from("  Down"),
                         Span::from(" | "),
-                        Span::from("s").bold(),
+                        Span::from(toggle_scanning.clone()).bold(),
                         Span::from("  Scan on/off"),
                         Span::from(" | "),
                         Span::from(config.paired_device.unpair.to_string()).bold(),
@@ -57,7 +63,7 @@ impl Help {
                             Span::from("󱁐  or ↵ ").bold(),
                             Span::from(" Dis/Connect"),
                             Span::from(" | "),
-                            Span::from("s").bold(),
+                            Span::from(toggle_scanning.clone()).bold(),
                             Span::from("  Scan on/off"),
                             Span::from(" | "),
                             Span::from(config.paired_device.unpair.to_string()).bold(),
@@ -73,10 +79,12 @@ impl Help {
                             Span::from(config.paired_device.rename.to_string()).bold(),
                             Span::from(" Rename"),
                             Span::from(" | "),
-                            Span::from("k,").bold(),
+                            Span::from(nav_up.clone()).bold(),
+                            Span::from(",").bold(),
                             Span::from("  Up"),
                             Span::from(" | "),
-                            Span::from("j,").bold(),
+                            Span::from(nav_down.clone()).bold(),
+                            Span::from(",").bold(),
                             Span::from("  Down"),
                             Span::from(" | "),
                             Span::from("⇄").bold(),
@@ -86,16 +94,18 @@ impl Help {
                 }
             }
             FocusedBlock::NewDevices => vec![Line::from(vec![
-                Span::from("k,").bold(),
+                Span::from(nav_up.clone()).bold(),
+                Span::from(",").bold(),
                 Span::from("  Up"),
                 Span::from(" | "),
-                Span::from("j,").bold(),
+                Span::from(nav_down.clone()).bold(),
+                Span::from(",").bold(),
                 Span::from("  Down"),
                 Span::from(" | "),
                 Span::from("󱁐  or ↵ ").bold(),
                 Span::from(" Pair"),
                 Span::from(" | "),
-                Span::from("s").bold(),
+                Span::from(toggle_scanning.clone()).bold(),
                 Span::from("  Scan on/off"),
                 Span::from(" | "),
                 Span::from("⇄").bold(),
@@ -104,7 +114,7 @@ impl Help {
             FocusedBlock::Adapter => {
                 if area.width > 80 {
                     vec![Line::from(vec![
-                        Span::from("s").bold(),
+                        Span::from(toggle_scanning.clone()).bold(),
                         Span::from("  Scan on/off"),
                         Span::from(" | "),
                         Span::from(config.adapter.toggle_pairing.to_string()).bold(),
@@ -122,7 +132,7 @@ impl Help {
                 } else {
                     vec![
                         Line::from(vec![
-                            Span::from("s").bold(),
+                            Span::from(toggle_scanning.clone()).bold(),
                             Span::from("  Scan on/off"),
                             Span::from(" | "),
                             Span::from(config.adapter.toggle_pairing.to_string()).bold(),

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,13 +1,14 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Text},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
 };
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{app::AppResult, event::Event, string_ref::StringRef};
+use crate::{app::AppResult, config::Config, event::Event, string_ref::StringRef};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct Notification {
@@ -24,11 +25,11 @@ pub enum NotificationLevel {
 }
 
 impl Notification {
-    pub fn render(&self, index: usize, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, index: usize, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let (color, title) = match self.level {
-            NotificationLevel::Info => (Color::Green, "Info"),
-            NotificationLevel::Warning => (Color::Yellow, "Warning"),
-            NotificationLevel::Error => (Color::Red, "Error"),
+            NotificationLevel::Info => (config.colors.info, "Info"),
+            NotificationLevel::Warning => (config.colors.warning, "Warning"),
+            NotificationLevel::Error => (config.colors.error, "Error"),
         };
 
         let mut text = Text::from(vec![

--- a/src/requests/confirmation.rs
+++ b/src/requests/confirmation.rs
@@ -1,14 +1,15 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, config::Config};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct Confirmation {
@@ -48,7 +49,7 @@ impl Confirmation {
         self.confirmed = !self.confirmed;
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let block = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -96,7 +97,7 @@ impl Confirmation {
                 Span::from("Confirm Passkey "),
                 Span::styled(
                     format!("{:06}", self.passkey),
-                    Style::new().bg(Color::DarkGray).bold(),
+                    Style::new().bg(config.colors.highlight_bg).bold(),
                 ),
             ])
             .centered(),
@@ -108,13 +109,13 @@ impl Confirmation {
                     Span::from("No").style(Style::default()),
                     Span::from("        "),
                     Span::from("Yes")
-                        .style(Style::default().bg(Color::Blue))
+                        .style(Style::default().bg(config.colors.info))
                         .bold(),
                 ])
             } else {
                 Line::from(vec![
                     Span::from("No")
-                        .style(Style::default().bg(Color::Blue))
+                        .style(Style::default().bg(config.colors.info))
                         .bold(),
                     Span::from("        "),
                     Span::from("Yes").style(Style::default()),
@@ -128,7 +129,7 @@ impl Confirmation {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(config.colors.focused_border)),
             block,
         );
         frame.render_widget(message, message_block);

--- a/src/requests/display_passkey.rs
+++ b/src/requests/display_passkey.rs
@@ -1,14 +1,15 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, config::Config};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct DisplayPasskey {
@@ -36,7 +37,7 @@ impl DisplayPasskey {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let block = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -67,7 +68,7 @@ impl DisplayPasskey {
             Line::from(""),
             Line::from(self.passkey.to_string())
                 .bold()
-                .bg(Color::DarkGray),
+                .bg(config.colors.highlight_bg),
         ];
 
         let message = Paragraph::new(message).centered();
@@ -78,7 +79,7 @@ impl DisplayPasskey {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(config.colors.focused_border)),
             block,
         );
         frame.render_widget(

--- a/src/requests/display_pin_code.rs
+++ b/src/requests/display_pin_code.rs
@@ -1,14 +1,15 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::Line,
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, config::Config};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct DisplayPinCode {
@@ -34,7 +35,7 @@ impl DisplayPinCode {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let block = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -61,7 +62,7 @@ impl DisplayPinCode {
             Line::from(self.pin_code.clone())
                 .centered()
                 .bold()
-                .bg(Color::DarkGray),
+                .bg(config.colors.highlight_bg),
         ];
 
         let message = Paragraph::new(message).centered();
@@ -72,7 +73,7 @@ impl DisplayPinCode {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(config.colors.focused_border)),
             block,
         );
         frame.render_widget(

--- a/src/requests/enter_passkey.rs
+++ b/src/requests/enter_passkey.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, List},
 };
@@ -14,9 +14,11 @@ use tui_input::{Input, backend::crossterm::EventHandler};
 use crate::{
     agent::AuthAgent,
     app::AppResult,
+    config::Config,
     event::Event,
     requests::{pad_str, pad_string},
 };
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum FocusedSection {
@@ -121,7 +123,7 @@ impl EnterPasskey {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -176,14 +178,14 @@ impl EnterPasskey {
             Line::from(vec![
                 {
                     if self.focused_section == FocusedSection::Input {
-                        Span::from("Passkey").green().bold()
+                        Span::from("Passkey").fg(config.colors.focused_header).bold()
                     } else {
                         Span::from("Passkey")
                     }
                 },
                 Span::from("  "),
                 Span::from(pad_string(format!(" {}", self.passkey.field.value()), 60))
-                    .bg(Color::DarkGray),
+                    .bg(config.colors.highlight_bg),
             ]),
             Line::from(vec![Span::from(pad_str(" ", 9)), {
                 if let Some(error) = &self.passkey.error {
@@ -192,13 +194,13 @@ impl EnterPasskey {
                     Span::from("")
                 }
             }])
-            .red(),
+            .fg(config.colors.error),
         ];
 
         let user_input = List::new(items);
 
         let submit = if self.focused_section == FocusedSection::Submit {
-            Text::from("Submit").centered().bold().green()
+            Text::from("Submit").centered().bold().fg(config.colors.focused_header)
         } else {
             Text::from("Submit").centered()
         };
@@ -209,7 +211,7 @@ impl EnterPasskey {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(config.colors.focused_border)),
             block,
         );
 

--- a/src/requests/enter_pin_code.rs
+++ b/src/requests/enter_pin_code.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, List},
 };
@@ -14,9 +14,11 @@ use tui_input::{Input, backend::crossterm::EventHandler};
 use crate::{
     agent::AuthAgent,
     app::AppResult,
+    config::Config,
     event::Event,
     requests::{pad_str, pad_string},
 };
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum FocusedSection {
@@ -115,7 +117,7 @@ impl EnterPinCode {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, config: Arc<Config>) {
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -170,14 +172,14 @@ impl EnterPinCode {
             Line::from(vec![
                 {
                     if self.focused_section == FocusedSection::Input {
-                        Span::from("Pin Code").green().bold()
+                        Span::from("Pin Code").fg(config.colors.focused_header).bold()
                     } else {
                         Span::from("Pin Code")
                     }
                 },
                 Span::from("  "),
                 Span::from(pad_string(format!(" {}", self.pin_code.field.value()), 60))
-                    .bg(Color::DarkGray),
+                    .bg(config.colors.highlight_bg),
             ]),
             Line::from(vec![Span::from(pad_str(" ", 10)), {
                 if let Some(error) = &self.pin_code.error {
@@ -186,13 +188,13 @@ impl EnterPinCode {
                     Span::from("")
                 }
             }])
-            .red(),
+            .fg(config.colors.error),
         ];
 
         let user_input = List::new(items);
 
         let submit = if self.focused_section == FocusedSection::Submit {
-            Text::from("Submit").centered().bold().green()
+            Text::from("Submit").centered().bold().fg(config.colors.focused_header)
         } else {
             Text::from("Submit").centered()
         };
@@ -203,7 +205,7 @@ impl EnterPinCode {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(Style::default().fg(config.colors.focused_border)),
             block,
         );
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,6 +6,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     app.render(frame);
 
     for (index, notification) in app.notifications.iter().enumerate() {
-        notification.render(index, frame, app.area(frame));
+        notification.render(index, frame, app.area(frame), app.config.clone());
     }
 }


### PR DESCRIPTION
This PR adds configurable keybindings for navigation keys, complementing the existing customizable action keys.

Closes https://github.com/pythops/bluetui/issues/120.

#### New Configuration Options

Added a `[navigation]` section to the config file with the following options:

| Key | Default | Description |
|-----|---------|-------------|
| `up` | `k` | Scroll up in lists |
| `down` | `j` | Scroll down in lists |
| `left` | `h` | Switch focus to previous section |
| `right` | `l` | Switch focus to next section |
| `quit` | `q` | Quit the application |
| `select` | ` ` (space) | Connect/disconnect or pair device |

#### Example Configuration

```/dev/null/config.toml#L1-L7
[navigation]
up = "i"
down = "e"
left = "n"
right = "o"
quit = "q"
select = " "
```

#### Changes

- **src/config.rs**: Added `Navigation` struct with configurable keys and defaults
- **src/handler.rs**: Updated key event handling to use configurable navigation keys
- **src/help.rs**: Help text now displays the actual configured keys
- **Readme.md**: Documented the new `[navigation]` config section
- **flake.nix**: Use rust-overlay for package builds (ensures compatible Rust version)

#### Notes

- Arrow keys (`Up`/`Down`) and `Tab`/`BackTab` continue to work as hardcoded alternatives for accessibility
- `Enter` remains hardcoded for connect/disconnect/pair actions
- `Ctrl+C` remains hardcoded for quit