### PR TITLE
feat: show spinner on busy paired devices

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -428,6 +428,11 @@ impl App {
                         } else {
                             "".to_string()
                         },
+                        if d.is_busy.load(Ordering::Relaxed) {
+                            "BUSY".to_string()
+                        } else {
+                            "".to_string()
+                        },
                         format!("{} {}", &d.icon, &d.alias),
                         d.is_trusted.to_string(),
                         d.is_connected.to_string(),
@@ -488,6 +493,7 @@ impl App {
 
             let mut widths = vec![
                 Constraint::Length(1),
+                Constraint::Length(4),
                 Constraint::Max(25),
                 Constraint::Length(7),
                 Constraint::Length(9),
@@ -503,6 +509,7 @@ impl App {
                         if self.focused_block == FocusedBlock::PairedDevices {
                             Row::new(vec![
                                 Cell::from("").style(Style::default().fg(Color::Yellow)),
+                                Cell::from("").style(Style::default().fg(Color::Yellow)),
                                 Cell::from("Name").style(Style::default().fg(Color::Yellow)),
                                 Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
                                 Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
@@ -512,6 +519,7 @@ impl App {
                             .bottom_margin(1)
                         } else {
                             Row::new(vec![
+                                Cell::from(""),
                                 Cell::from(""),
                                 Cell::from("Name"),
                                 Cell::from("Trusted"),
@@ -523,6 +531,7 @@ impl App {
                     } else if self.focused_block == FocusedBlock::PairedDevices {
                         Row::new(vec![
                             Cell::from("").style(Style::default().fg(Color::Yellow)),
+                            Cell::from("").style(Style::default().fg(Color::Yellow)),
                             Cell::from("Name").style(Style::default().fg(Color::Yellow)),
                             Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
                             Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
@@ -531,6 +540,7 @@ impl App {
                         .bottom_margin(1)
                     } else {
                         Row::new(vec![
+                            Cell::from(""),
                             Cell::from(""),
                             Cell::from("Name"),
                             Cell::from("Trusted"),

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -30,6 +30,10 @@ pub struct Device {
     pub is_trusted: bool,
     pub is_connected: bool,
     pub battery_percentage: Option<u8>,
+
+    /// user has requested connect/disconnect and (bluer) hasn't yet performed the action
+    /// when true, a spinner is shown in the ui
+    pub is_busy: Arc<AtomicBool>,
 }
 
 impl Device {
@@ -126,6 +130,7 @@ impl Controller {
                 is_connected,
                 is_favorite,
                 battery_percentage,
+                is_busy: Arc::new(AtomicBool::new(false)),
             };
 
             if dev.is_paired {


### PR DESCRIPTION
fixes #47

Does this look like a reasonable approach, adding a field `is_busy` to devices, then whenever we (dis)connect, we set that flag to `true`, and let the spawned tokio task turn it back to `false`, when it's done.

For now, I created a new column that shows the text `BUSY` when this flag is true.
