### PR TITLE
Show connecting spinner while connecting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,10 @@ use crate::{
     requests::Requests,
     spinner::Spinner,
 };
-use std::sync::{Arc, atomic::Ordering};
+use std::{
+    collections::HashSet,
+    sync::{Arc, atomic::Ordering},
+};
 
 pub type AppResult<T> = anyhow::Result<T>;
 
@@ -57,6 +60,7 @@ pub struct App {
     pub session: Arc<Session>,
     pub agent: AgentHandle,
     pub spinner: Spinner,
+    pub connecting_devices: HashSet<Address>,
     pub notifications: Vec<Notification>,
     pub controllers: Vec<Controller>,
     pub controller_state: TableState,
@@ -119,6 +123,7 @@ impl App {
             session,
             agent: handle,
             spinner: Spinner::default(),
+            connecting_devices: HashSet::new(),
             notifications: Vec::new(),
             controllers,
             controller_state,
@@ -422,6 +427,13 @@ impl App {
                 .paired_devices
                 .iter()
                 .map(|d| {
+                    let connected_cell = if self.connecting_devices.contains(&d.addr) {
+                        // Keep the UI responsive while connect() is in progress.
+                        format!("Connecting {}", self.spinner.draw())
+                    } else {
+                        d.is_connected.to_string()
+                    };
+
                     Row::new(vec![
                         if d.is_favorite {
                             STAR_SYMBOL.to_string()
@@ -430,7 +442,7 @@ impl App {
                         },
                         format!("{} {}", &d.icon, &d.alias),
                         d.is_trusted.to_string(),
-                        d.is_connected.to_string(),
+                        connected_cell,
                         {
                             if let Some(battery_percentage) = d.battery_percentage {
                                 match battery_percentage {
@@ -744,7 +756,7 @@ impl App {
         self.notifications.retain(|n| n.ttl > 0);
         self.notifications.iter_mut().for_each(|n| n.ttl -= 1);
 
-        if self.spinner.active {
+        if self.spinner.active || !self.connecting_devices.is_empty() {
             self.spinner.update();
         }
         self.refresh().await?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -23,6 +23,8 @@ pub enum Event {
     Mouse(MouseEvent),
     Resize(u16, u16),
     Notification(Notification),
+    DeviceConnectionStarted(Address),
+    DeviceConnectionFinished(Address),
     NewPairedDevice(Address),
     ToggleFavorite(Address),
     FailedPairing(Address),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -40,8 +40,10 @@ async fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) {
                                         }
                                     }
                                 } else {
+                                    let _ = sender.send(Event::DeviceConnectionStarted(addr));
                                     match device.connect().await {
                                         Ok(_) => {
+                                            let _ = sender.send(Event::DeviceConnectionFinished(addr));
                                             let _ = Notification::send(
                                                 "Device connected".into(),
                                                 NotificationLevel::Info,
@@ -49,6 +51,7 @@ async fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) {
                                             );
                                         }
                                         Err(e) => {
+                                            let _ = sender.send(Event::DeviceConnectionFinished(addr));
                                             let _ = Notification::send(
                                                 e.into(),
                                                 NotificationLevel::Error,
@@ -116,7 +119,12 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                                             );
                                         }
                                     };
-                                    match device.connect().await {
+                                    let addr = device.address();
+                                    let _ = sender.send(Event::DeviceConnectionStarted(addr));
+                                    let res = device.connect().await;
+                                    let _ = sender.send(Event::DeviceConnectionFinished(addr));
+
+                                    match res {
                                         Ok(_) => {
                                             let _ = Notification::send(
                                                 "Device connected".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,12 @@ async fn main() -> AppResult<()> {
             Event::Notification(notification) => {
                 app.notifications.push(notification);
             }
+            Event::DeviceConnectionStarted(address) => {
+                app.connecting_devices.insert(address);
+            }
+            Event::DeviceConnectionFinished(address) => {
+                app.connecting_devices.remove(&address);
+            }
             Event::NewPairedDevice(address) => {
                 if let Some(req) = &app.requests.display_passkey
                     && req.device == address


### PR DESCRIPTION
When connecting a paired device, the UI currently stays on "false" until the refresh picks up the new state. This adds a transient "Connecting <spinner>" indicator while connect() is in progress so the user knows the action was registered.