### PR TITLE
fix passkey display starting with 0

### DIFF
--- a/src/requests/display_passkey.rs
+++ b/src/requests/display_passkey.rs
@@ -65,7 +65,7 @@ impl DisplayPasskey {
             )])
             .centered(),
             Line::from(""),
-            Line::from(self.passkey.to_string())
+            Line::from(format!("{:06}", self.passkey))
                 .bold()
                 .bg(Color::DarkGray),
         ];


### PR DESCRIPTION
When a passkey is displayed to the user after pairing with a keyboard and it starts with zero it displays a 5 digit key.  If the user does not enter the `0` to start entering the passkey on the keyboard, the pairing will not work.

This fix forces the display to always have 6 digits.
