### PR TITLE
Add configurable theme file support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,16 +200,6 @@ Supported color formats:
 - named colors such as `green`, `yellow`, `white`, `darkgray`, `reset`
 - hex colors in `#RRGGBB` format
 
-### Omarchy
-
-`bluetui` can integrate cleanly with Omarchy by pointing `theme_file` at a generated theme file, for example:
-
-```toml
-theme_file = "~/.config/omarchy/current/theme/bluetui.toml"
-```
-
-This makes it possible to keep `bluetui` in sync with the active Omarchy theme without adding any Omarchy-specific logic to `bluetui` itself.
-
 ## Contributing
 
 - No AI slop.

--- a/Readme.md
+++ b/Readme.md
@@ -101,7 +101,7 @@ This will produce an executable file at `target/release/bluetui` that you can co
 
 ## Config
 
-Keybindings can be customized in the default config file location `$HOME/.config/bluetui/config.toml` or from a custom path with `-c`
+Keybindings and theming can be customized in the default config file location `$HOME/.config/bluetui/config.toml` or from a custom path with `-c`
 
 ```toml
 # Possible values: "Legacy", "Start", "End", "Center", "SpaceAround", "SpaceBetween"
@@ -110,6 +110,10 @@ layout = "SpaceAround"
 # Window width
 # Possible values: "auto" or a positive integer
 width = "auto"
+
+# Optional path to a theme file.
+# Supports `~` expansion. Relative paths are resolved against the config file directory.
+theme_file = "~/.config/bluetui/theme.toml"
 
 toggle_scanning = "s"
 esc_quit = false  # Set to true to enable Esc key to quit the app
@@ -125,6 +129,86 @@ toggle_trust = "t"
 toggle_favorite = "f"
 rename = "e"
 ```
+
+## Theme
+
+`bluetui` can load an optional TOML theme file via `theme_file`.
+
+- If the file is missing, `bluetui` falls back to the built-in default theme.
+- If the file exists but contains invalid TOML or invalid color values, `bluetui` exits with a clear error.
+
+Example:
+
+```toml
+[focused_border]
+fg = "#509475"
+
+[focused_title]
+fg = "#509475"
+modifiers = ["bold"]
+
+[selected_row]
+fg = "#111C18"
+bg = "#C1C497"
+modifiers = ["bold"]
+
+[header]
+fg = "#509475"
+modifiers = ["bold"]
+
+[input]
+fg = "#C1C497"
+bg = "#53685B"
+
+[popup_border]
+fg = "#509475"
+
+[popup_text]
+fg = "#C1C497"
+
+[button_active]
+fg = "#111c18"
+bg = "#509475"
+modifiers = ["bold"]
+
+[button_inactive]
+fg = "#C1C497"
+
+[notification_info]
+fg = "#549e6a"
+modifiers = ["bold"]
+
+[notification_warning]
+fg = "#E5C736"
+modifiers = ["bold"]
+
+[notification_error]
+fg = "#FF5345"
+modifiers = ["bold"]
+```
+
+Supported modifiers:
+
+- `bold`
+- `italic`
+- `underlined`
+- `reversed`
+- `dim`
+
+Supported color formats:
+
+- named colors such as `green`, `yellow`, `white`, `darkgray`, `reset`
+- hex colors in `#RRGGBB` format
+
+### Omarchy
+
+`bluetui` can integrate cleanly with Omarchy by pointing `theme_file` at a generated theme file, for example:
+
+```toml
+theme_file = "~/.config/omarchy/current/theme/bluetui.toml"
+```
+
+This makes it possible to keep `bluetui` in sync with the active Omarchy theme without adding any Omarchy-specific logic to `bluetui` itself.
 
 ## Contributing
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use futures::FutureExt;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout, Margin, Rect},
-    style::{Color, Modifier, Style, Stylize},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{
         Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Scrollbar,
@@ -31,6 +31,7 @@ use crate::{
     notification::Notification,
     requests::Requests,
     spinner::Spinner,
+    theme::Theme,
 };
 use std::sync::{Arc, atomic::Ordering};
 
@@ -66,12 +67,17 @@ pub struct App {
     pub focused_block: FocusedBlock,
     pub new_alias: Input,
     pub config: Arc<Config>,
+    pub theme: Arc<Theme>,
     pub requests: Requests,
     pub auth_agent: AuthAgent,
 }
 
 impl App {
-    pub async fn new(config: Arc<Config>, sender: UnboundedSender<Event>) -> AppResult<Self> {
+    pub async fn new(
+        config: Arc<Config>,
+        theme: Arc<Theme>,
+        sender: UnboundedSender<Event>,
+    ) -> AppResult<Self> {
         let session = Arc::new(bluer::Session::new().await?);
 
         let auth_agent = AuthAgent::new(sender.clone());
@@ -128,6 +134,7 @@ impl App {
             focused_block: FocusedBlock::PairedDevices,
             new_alias: Input::default(),
             config,
+            theme,
             requests: Requests::default(),
             auth_agent,
         })
@@ -221,8 +228,8 @@ impl App {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .style(Style::default().green())
-                .border_style(Style::default().fg(Color::Green)),
+                .style(self.theme.popup_border)
+                .border_style(self.theme.popup_border),
             block,
         );
 
@@ -241,15 +248,15 @@ impl App {
 
                 let msg = Paragraph::new(text)
                     .alignment(Alignment::Center)
-                    .style(Style::default().fg(Color::White))
+                    .style(self.theme.popup_text)
                     .block(Block::new().padding(Padding::horizontal(2)));
 
                 let alias = Paragraph::new(self.new_alias.value())
                     .alignment(Alignment::Left)
-                    .style(Style::default().fg(Color::White))
+                    .style(self.theme.input)
                     .block(
                         Block::new()
-                            .bg(Color::DarkGray)
+                            .style(self.theme.input)
                             .padding(Padding::horizontal(2)),
                     );
 
@@ -329,13 +336,13 @@ impl App {
                 .header({
                     if self.focused_block == FocusedBlock::Adapter {
                         Row::new(vec![
-                            Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Alias").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Power").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Pairable").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Discoverable").style(Style::default().fg(Color::Yellow)),
+                            Cell::from("Name"),
+                            Cell::from("Alias"),
+                            Cell::from("Power"),
+                            Cell::from("Pairable"),
+                            Cell::from("Discoverable"),
                         ])
-                        .style(Style::new().bold())
+                        .style(self.theme.header)
                         .bottom_margin(1)
                     } else {
                         Row::new(vec![
@@ -353,7 +360,7 @@ impl App {
                         .title(" Adapter ")
                         .title_style({
                             if self.focused_block == FocusedBlock::Adapter {
-                                Style::default().bold()
+                                self.theme.focused_title
                             } else {
                                 Style::default()
                             }
@@ -361,7 +368,7 @@ impl App {
                         .borders(Borders::ALL)
                         .border_style({
                             if self.focused_block == FocusedBlock::Adapter {
-                                Style::default().fg(Color::Green)
+                                self.theme.focused_border
                             } else {
                                 Style::default()
                             }
@@ -376,7 +383,7 @@ impl App {
                 )
                 .flex(self.config.layout)
                 .row_highlight_style(if self.focused_block == FocusedBlock::Adapter {
-                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                    self.theme.selected_row
                 } else {
                     Style::default()
                 });
@@ -488,13 +495,13 @@ impl App {
                     if show_battery_column {
                         if self.focused_block == FocusedBlock::PairedDevices {
                             Row::new(vec![
-                                Cell::from("").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
-                                Cell::from("Battery").style(Style::default().fg(Color::Yellow)),
+                                Cell::from(""),
+                                Cell::from("Name"),
+                                Cell::from("Trusted"),
+                                Cell::from("Connected"),
+                                Cell::from("Battery"),
                             ])
-                            .style(Style::new().bold())
+                            .style(self.theme.header)
                             .bottom_margin(1)
                         } else {
                             Row::new(vec![
@@ -508,12 +515,12 @@ impl App {
                         }
                     } else if self.focused_block == FocusedBlock::PairedDevices {
                         Row::new(vec![
-                            Cell::from("").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Name").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Trusted").style(Style::default().fg(Color::Yellow)),
-                            Cell::from("Connected").style(Style::default().fg(Color::Yellow)),
+                            Cell::from(""),
+                            Cell::from("Name"),
+                            Cell::from("Trusted"),
+                            Cell::from("Connected"),
                         ])
-                        .style(Style::new().bold())
+                        .style(self.theme.header)
                         .bottom_margin(1)
                     } else {
                         Row::new(vec![
@@ -531,7 +538,7 @@ impl App {
                         .title(" Paired Devices ")
                         .title_style({
                             if self.focused_block == FocusedBlock::PairedDevices {
-                                Style::default().bold()
+                                self.theme.focused_title
                             } else {
                                 Style::default()
                             }
@@ -539,7 +546,7 @@ impl App {
                         .borders(Borders::ALL)
                         .border_style({
                             if self.focused_block == FocusedBlock::PairedDevices {
-                                Style::default().fg(Color::Green)
+                                self.theme.focused_border
                             } else {
                                 Style::default()
                             }
@@ -554,7 +561,7 @@ impl App {
                 )
                 .flex(self.config.layout)
                 .row_highlight_style(if self.focused_block == FocusedBlock::PairedDevices {
-                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                    self.theme.selected_row
                 } else {
                     Style::default()
                 });
@@ -602,10 +609,10 @@ impl App {
                     .header({
                         if self.focused_block == FocusedBlock::NewDevices {
                             Row::new(vec![
-                                Cell::from(Line::from("Address").fg(Color::Yellow).centered()),
-                                Cell::from(Line::from("Name").fg(Color::Yellow).centered()),
+                                Cell::from(Line::from("Address").centered()),
+                                Cell::from(Line::from("Name").centered()),
                             ])
-                            .style(Style::new().bold())
+                            .style(self.theme.header)
                             .bottom_margin(1)
                         } else {
                             Row::new(vec![
@@ -627,7 +634,7 @@ impl App {
                             })
                             .title_style({
                                 if self.focused_block == FocusedBlock::NewDevices {
-                                    Style::default().bold()
+                                    self.theme.focused_title
                                 } else {
                                     Style::default()
                                 }
@@ -635,7 +642,7 @@ impl App {
                             .borders(Borders::ALL)
                             .border_style({
                                 if self.focused_block == FocusedBlock::NewDevices {
-                                    Style::default().fg(Color::Green)
+                                    self.theme.focused_border
                                 } else {
                                     Style::default()
                                 }
@@ -650,7 +657,7 @@ impl App {
                     )
                     .flex(self.config.layout)
                     .row_highlight_style(if self.focused_block == FocusedBlock::NewDevices {
-                        Style::default().bg(Color::DarkGray).fg(Color::White)
+                        self.theme.selected_row
                     } else {
                         Style::default()
                     });
@@ -700,28 +707,28 @@ impl App {
 
             // Request Confirmation
             if let Some(req) = &self.requests.confirmation {
-                req.render(frame, area);
+                req.render(frame, area, &self.theme);
             }
 
             // Request to enter pin code
 
             if let Some(req) = &self.requests.enter_pin_code {
-                req.render(frame, area);
+                req.render(frame, area, &self.theme);
             }
 
             // Request passkey
             if let Some(req) = &self.requests.enter_passkey {
-                req.render(frame, area);
+                req.render(frame, area, &self.theme);
             }
 
             // Display Pin Code
             if let Some(req) = &self.requests.display_pin_code {
-                req.render(frame, area);
+                req.render(frame, area, &self.theme);
             }
 
             // Display Passkey
             if let Some(req) = &self.requests.display_passkey {
-                req.render(frame, area);
+                req.render(frame, area, &self.theme);
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
 use core::fmt;
-use std::{path::PathBuf, process::exit};
+use std::{
+    path::{Path, PathBuf},
+    process::exit,
+};
 
 use ratatui::layout::Flex;
 use toml;
@@ -23,6 +26,9 @@ pub struct Config {
 
     #[serde(default = "default_esc_quit")]
     pub esc_quit: bool,
+
+    #[serde(default)]
+    pub theme_file: Option<PathBuf>,
 
     #[serde(default)]
     pub adapter: Adapter,
@@ -210,8 +216,8 @@ impl Config {
                 .join("config.toml"),
         );
 
-        let config = std::fs::read_to_string(conf_path).unwrap_or_default();
-        let app_config: Config = match toml::from_str(&config) {
+        let config = std::fs::read_to_string(&conf_path).unwrap_or_default();
+        let mut app_config: Config = match toml::from_str(&config) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("{}", e);
@@ -219,6 +225,53 @@ impl Config {
             }
         };
 
+        app_config.theme_file = app_config.theme_file.take().map(|path| {
+            resolve_theme_file_path(path, conf_path.parent().unwrap_or(Path::new(".")))
+        });
+
         app_config
+    }
+}
+
+fn resolve_theme_file_path(path: PathBuf, config_dir: &Path) -> PathBuf {
+    let expanded = expand_tilde(path);
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        config_dir.join(expanded)
+    }
+}
+
+fn expand_tilde(path: PathBuf) -> PathBuf {
+    let path_str = path.to_string_lossy();
+    if path_str == "~" {
+        return dirs::home_dir().unwrap_or(path);
+    }
+
+    if let Some(rest) = path_str.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_relative_theme_file_against_config_dir() {
+        let resolved = resolve_theme_file_path(PathBuf::from("theme.toml"), Path::new("/tmp/app"));
+        assert_eq!(resolved, PathBuf::from("/tmp/app/theme.toml"));
+    }
+
+    #[test]
+    fn expands_tilde_theme_file() {
+        let resolved =
+            resolve_theme_file_path(PathBuf::from("~/theme.toml"), Path::new("/tmp/app"));
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with("theme.toml"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,6 @@ pub mod requests;
 pub mod rfkill;
 pub mod spinner;
 pub mod string_ref;
+pub mod theme;
 pub mod tui;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use bluetui::{
     event::{Event, EventHandler},
     handler::handle_key_events,
     rfkill,
+    theme::Theme,
     tui::Tui,
 };
 use clap::Parser;
@@ -27,6 +28,7 @@ async fn main() -> AppResult<()> {
     rfkill::check()?;
 
     let config = Arc::new(Config::new(config_file_path));
+    let theme = Arc::new(Theme::load(config.theme_file.as_deref())?);
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;
@@ -35,7 +37,7 @@ async fn main() -> AppResult<()> {
 
     tui.init()?;
 
-    let mut app = App::new(config.clone(), tui.events.sender.clone()).await?;
+    let mut app = App::new(config.clone(), theme, tui.events.sender.clone()).await?;
 
     while app.running {
         tui.draw(&mut app)?;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,13 +1,13 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Text},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
 };
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{app::AppResult, event::Event, string_ref::StringRef};
+use crate::{app::AppResult, event::Event, string_ref::StringRef, theme::Theme};
 
 #[derive(Debug, Clone)]
 pub struct Notification {
@@ -24,15 +24,15 @@ pub enum NotificationLevel {
 }
 
 impl Notification {
-    pub fn render(&self, index: usize, frame: &mut Frame, area: Rect) {
-        let (color, title) = match self.level {
-            NotificationLevel::Info => (Color::Green, "Info"),
-            NotificationLevel::Warning => (Color::Yellow, "Warning"),
-            NotificationLevel::Error => (Color::Red, "Error"),
+    pub fn render(&self, index: usize, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let (style, title) = match self.level {
+            NotificationLevel::Info => (theme.notification_info, "Info"),
+            NotificationLevel::Warning => (theme.notification_warning, "Warning"),
+            NotificationLevel::Error => (theme.notification_error, "Error"),
         };
 
         let mut text = Text::from(vec![
-            Line::from(title).style(Style::new().fg(color).add_modifier(Modifier::BOLD)),
+            Line::from(title).style(style.add_modifier(Modifier::BOLD)),
         ]);
 
         text.extend(Text::from(self.message.as_str()));
@@ -48,7 +48,7 @@ impl Notification {
                     .borders(Borders::ALL)
                     .style(Style::default())
                     .border_type(BorderType::Thick)
-                    .border_style(Style::default().fg(color)),
+                    .border_style(style),
             );
 
         let area = notification_rect(index as u16, notification_height, notification_width, area);
@@ -120,7 +120,7 @@ mod tests {
                     level: level.clone(),
                     ttl: 1,
                 };
-                notification.render(0, frame, frame.area());
+                notification.render(0, frame, frame.area(), &Theme::default());
             })
             .unwrap();
 
@@ -155,7 +155,7 @@ nisi. Fusce velit nibh, euismod vel lectus id, placerat."#
                     level: level.clone(),
                     ttl: 1,
                 };
-                notification.render(0, frame, frame.area());
+                notification.render(0, frame, frame.area(), &Theme::default());
             })
             .unwrap();
 

--- a/src/requests/confirmation.rs
+++ b/src/requests/confirmation.rs
@@ -1,14 +1,14 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::Modifier,
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, theme::Theme};
 
 #[derive(Debug, Clone)]
 pub struct Confirmation {
@@ -48,7 +48,7 @@ impl Confirmation {
         self.confirmed = !self.confirmed;
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let block = Layout::vertical([
             Constraint::Fill(1),
             Constraint::Length(8),
@@ -90,7 +90,7 @@ impl Confirmation {
                 Span::from("Confirm Passkey "),
                 Span::styled(
                     format!("{:06}", self.passkey),
-                    Style::new().bg(Color::DarkGray).bold(),
+                    theme.input.add_modifier(Modifier::BOLD),
                 ),
             ])
             .centered(),
@@ -99,19 +99,15 @@ impl Confirmation {
         let choice = {
             if self.confirmed {
                 Line::from(vec![
-                    Span::from("No").style(Style::default()),
+                    Span::from("No").style(theme.button_inactive),
                     Span::from("        "),
-                    Span::from("Yes")
-                        .style(Style::default().bg(Color::Blue))
-                        .bold(),
+                    Span::from("Yes").style(theme.button_active),
                 ])
             } else {
                 Line::from(vec![
-                    Span::from("No")
-                        .style(Style::default().bg(Color::Blue))
-                        .bold(),
+                    Span::from("No").style(theme.button_active),
                     Span::from("        "),
-                    Span::from("Yes").style(Style::default()),
+                    Span::from("Yes").style(theme.button_inactive),
                 ])
             }
         };
@@ -122,7 +118,7 @@ impl Confirmation {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(theme.popup_border),
             block,
         );
         frame.render_widget(message, message_block);
@@ -152,7 +148,7 @@ mod tests {
                     confirmation.toggle_select();
                 }
 
-                confirmation.render(frame, frame.area());
+                confirmation.render(frame, frame.area(), &Theme::default());
             })
             .unwrap();
 

--- a/src/requests/display_passkey.rs
+++ b/src/requests/display_passkey.rs
@@ -1,14 +1,14 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::Modifier,
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, theme::Theme};
 
 #[derive(Debug, Clone)]
 pub struct DisplayPasskey {
@@ -36,7 +36,7 @@ impl DisplayPasskey {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let block = Layout::vertical([
             Constraint::Fill(1),
             Constraint::Length(12),
@@ -61,12 +61,10 @@ impl DisplayPasskey {
             )])
             .centered(),
             Line::from(""),
-            Line::from(self.passkey.to_string())
-                .bold()
-                .bg(Color::DarkGray),
+            Line::from(self.passkey.to_string()).style(theme.input.add_modifier(Modifier::BOLD)),
         ];
 
-        let message = Paragraph::new(message).centered();
+        let message = Paragraph::new(message).centered().style(theme.popup_text);
 
         frame.render_widget(Clear, block);
 
@@ -74,7 +72,7 @@ impl DisplayPasskey {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(theme.popup_border),
             block,
         );
         frame.render_widget(

--- a/src/requests/display_pin_code.rs
+++ b/src/requests/display_pin_code.rs
@@ -1,14 +1,14 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::Modifier,
     text::Line,
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
 use bluer::Address;
 
-use crate::{agent::AuthAgent, app::AppResult};
+use crate::{agent::AuthAgent, app::AppResult, theme::Theme};
 
 #[derive(Debug, Clone)]
 pub struct DisplayPinCode {
@@ -34,7 +34,7 @@ impl DisplayPinCode {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let block = Layout::vertical([
             Constraint::Fill(1),
             Constraint::Length(10),
@@ -56,11 +56,10 @@ impl DisplayPinCode {
             Line::from(""),
             Line::from(self.pin_code.clone())
                 .centered()
-                .bold()
-                .bg(Color::DarkGray),
+                .style(theme.input.add_modifier(Modifier::BOLD)),
         ];
 
-        let message = Paragraph::new(message).centered();
+        let message = Paragraph::new(message).centered().style(theme.popup_text);
 
         frame.render_widget(Clear, block);
 
@@ -68,7 +67,7 @@ impl DisplayPinCode {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(theme.popup_border),
             block,
         );
         frame.render_widget(

--- a/src/requests/enter_passkey.rs
+++ b/src/requests/enter_passkey.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::Modifier,
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, List},
 };
@@ -16,6 +16,7 @@ use crate::{
     app::AppResult,
     event::Event,
     requests::{pad_str, pad_string},
+    theme::Theme,
 };
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -121,7 +122,7 @@ impl EnterPasskey {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let layout = Layout::vertical([
             Constraint::Fill(1),
             Constraint::Length(8),
@@ -170,29 +171,32 @@ impl EnterPasskey {
             Line::from(vec![
                 {
                     if self.focused_section == FocusedSection::Input {
-                        Span::from("Passkey").green().bold()
+                        Span::styled("Passkey", theme.focused_border.add_modifier(Modifier::BOLD))
                     } else {
                         Span::from("Passkey")
                     }
                 },
                 Span::from("  "),
-                Span::from(pad_string(format!(" {}", self.passkey.field.value()), 60))
-                    .bg(Color::DarkGray),
+                Span::styled(
+                    pad_string(format!(" {}", self.passkey.field.value()), 60),
+                    theme.input,
+                ),
             ]),
             Line::from(vec![Span::from(pad_str(" ", 9)), {
                 if let Some(error) = &self.passkey.error {
-                    Span::from(pad_str(error, 60))
+                    Span::styled(pad_str(error, 60), theme.notification_error)
                 } else {
                     Span::from("")
                 }
-            }])
-            .red(),
+            }]),
         ];
 
         let user_input = List::new(items);
 
         let submit = if self.focused_section == FocusedSection::Submit {
-            Text::from("Submit").centered().bold().green()
+            Text::from("Submit")
+                .centered()
+                .style(theme.focused_border.add_modifier(Modifier::BOLD))
         } else {
             Text::from("Submit").centered()
         };
@@ -203,11 +207,11 @@ impl EnterPasskey {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(theme.popup_border),
             block,
         );
 
-        frame.render_widget(message, message_block);
+        frame.render_widget(message.style(theme.popup_text), message_block);
         frame.render_widget(user_input, input_block);
         frame.render_widget(submit, submit_block);
     }

--- a/src/requests/enter_pin_code.rs
+++ b/src/requests/enter_pin_code.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::Modifier,
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, List},
 };
@@ -16,6 +16,7 @@ use crate::{
     app::AppResult,
     event::Event,
     requests::{pad_str, pad_string},
+    theme::Theme,
 };
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -115,7 +116,7 @@ impl EnterPinCode {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let layout = Layout::vertical([
             Constraint::Fill(1),
             Constraint::Length(8),
@@ -163,29 +164,35 @@ impl EnterPinCode {
             Line::from(vec![
                 {
                     if self.focused_section == FocusedSection::Input {
-                        Span::from("Pin Code").green().bold()
+                        Span::styled(
+                            "Pin Code",
+                            theme.focused_border.add_modifier(Modifier::BOLD),
+                        )
                     } else {
                         Span::from("Pin Code")
                     }
                 },
                 Span::from("  "),
-                Span::from(pad_string(format!(" {}", self.pin_code.field.value()), 60))
-                    .bg(Color::DarkGray),
+                Span::styled(
+                    pad_string(format!(" {}", self.pin_code.field.value()), 60),
+                    theme.input,
+                ),
             ]),
             Line::from(vec![Span::from(pad_str(" ", 10)), {
                 if let Some(error) = &self.pin_code.error {
-                    Span::from(pad_str(error, 60))
+                    Span::styled(pad_str(error, 60), theme.notification_error)
                 } else {
                     Span::from("")
                 }
-            }])
-            .red(),
+            }]),
         ];
 
         let user_input = List::new(items);
 
         let submit = if self.focused_section == FocusedSection::Submit {
-            Text::from("Submit").centered().bold().green()
+            Text::from("Submit")
+                .centered()
+                .style(theme.focused_border.add_modifier(Modifier::BOLD))
         } else {
             Text::from("Submit").centered()
         };
@@ -196,11 +203,11 @@ impl EnterPinCode {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(theme.popup_border),
             block,
         );
 
-        frame.render_widget(message, message_block);
+        frame.render_widget(message.style(theme.popup_text), message_block);
         frame.render_widget(user_input, input_block);
         frame.render_widget(submit, submit_block);
     }
@@ -217,8 +224,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
         terminal
             .draw(|frame| {
-                EnterPinCode::new("adapter".to_string(), Address::new(*b"DEADBE"))
-                    .render(frame, frame.area())
+                EnterPinCode::new("adapter".to_string(), Address::new(*b"DEADBE")).render(
+                    frame,
+                    frame.area(),
+                    &Theme::default(),
+                )
             })
             .unwrap();
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,319 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use ratatui::style::{Color, Modifier, Style};
+use serde::Deserialize;
+
+#[derive(Debug, Clone)]
+pub struct Theme {
+    pub focused_border: Style,
+    pub focused_title: Style,
+    pub selected_row: Style,
+    pub header: Style,
+    pub input: Style,
+    pub popup_border: Style,
+    pub popup_text: Style,
+    pub button_active: Style,
+    pub button_inactive: Style,
+    pub notification_info: Style,
+    pub notification_warning: Style,
+    pub notification_error: Style,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct ThemeFile {
+    focused_border: Option<StyleDef>,
+    focused_title: Option<StyleDef>,
+    selected_row: Option<StyleDef>,
+    header: Option<StyleDef>,
+    input: Option<StyleDef>,
+    popup_border: Option<StyleDef>,
+    popup_text: Option<StyleDef>,
+    button_active: Option<StyleDef>,
+    button_inactive: Option<StyleDef>,
+    notification_info: Option<StyleDef>,
+    notification_warning: Option<StyleDef>,
+    notification_error: Option<StyleDef>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
+struct StyleDef {
+    fg: Option<ColorDef>,
+    bg: Option<ColorDef>,
+    modifiers: Option<Vec<ModifierDef>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ColorDef(Color);
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ModifierDef {
+    Bold,
+    Italic,
+    Underlined,
+    Reversed,
+    Dim,
+}
+
+impl<'de> Deserialize<'de> for ColorDef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        parse_color(&value)
+            .map(ColorDef)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            focused_border: Style::default().fg(Color::Green),
+            focused_title: Style::default().add_modifier(Modifier::BOLD),
+            selected_row: Style::default().fg(Color::White).bg(Color::DarkGray),
+            header: Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+            input: Style::default().fg(Color::White).bg(Color::DarkGray),
+            popup_border: Style::default().fg(Color::Green),
+            popup_text: Style::default().fg(Color::White),
+            button_active: Style::default()
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+            button_inactive: Style::default(),
+            notification_info: Style::default().fg(Color::Green),
+            notification_warning: Style::default().fg(Color::Yellow),
+            notification_error: Style::default().fg(Color::Red),
+        }
+    }
+}
+
+impl Theme {
+    pub fn load(path: Option<&Path>) -> Result<Self> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read theme file {}", path.display()))?;
+        let theme_file: ThemeFile = toml::from_str(&content)
+            .with_context(|| format!("failed to parse theme file {}", path.display()))?;
+
+        Ok(Self::default().apply(theme_file))
+    }
+
+    fn apply(mut self, theme_file: ThemeFile) -> Self {
+        if let Some(style) = theme_file.focused_border {
+            self.focused_border = style.apply(self.focused_border);
+        }
+        if let Some(style) = theme_file.focused_title {
+            self.focused_title = style.apply(self.focused_title);
+        }
+        if let Some(style) = theme_file.selected_row {
+            self.selected_row = style.apply(self.selected_row);
+        }
+        if let Some(style) = theme_file.header {
+            self.header = style.apply(self.header);
+        }
+        if let Some(style) = theme_file.input {
+            self.input = style.apply(self.input);
+        }
+        if let Some(style) = theme_file.popup_border {
+            self.popup_border = style.apply(self.popup_border);
+        }
+        if let Some(style) = theme_file.popup_text {
+            self.popup_text = style.apply(self.popup_text);
+        }
+        if let Some(style) = theme_file.button_active {
+            self.button_active = style.apply(self.button_active);
+        }
+        if let Some(style) = theme_file.button_inactive {
+            self.button_inactive = style.apply(self.button_inactive);
+        }
+        if let Some(style) = theme_file.notification_info {
+            self.notification_info = style.apply(self.notification_info);
+        }
+        if let Some(style) = theme_file.notification_warning {
+            self.notification_warning = style.apply(self.notification_warning);
+        }
+        if let Some(style) = theme_file.notification_error {
+            self.notification_error = style.apply(self.notification_error);
+        }
+
+        self
+    }
+}
+
+impl StyleDef {
+    fn apply(&self, mut base: Style) -> Style {
+        if let Some(fg) = self.fg {
+            base = base.fg(fg.0);
+        }
+        if let Some(bg) = self.bg {
+            base = base.bg(bg.0);
+        }
+        if let Some(modifiers) = &self.modifiers {
+            for modifier in modifiers {
+                base = base.add_modifier(modifier.to_modifier());
+            }
+        }
+        base
+    }
+}
+
+impl ModifierDef {
+    fn to_modifier(self) -> Modifier {
+        match self {
+            Self::Bold => Modifier::BOLD,
+            Self::Italic => Modifier::ITALIC,
+            Self::Underlined => Modifier::UNDERLINED,
+            Self::Reversed => Modifier::REVERSED,
+            Self::Dim => Modifier::DIM,
+        }
+    }
+}
+
+fn parse_color(value: &str) -> Result<Color> {
+    let normalized = value.trim().to_ascii_lowercase();
+    let color = match normalized.as_str() {
+        "reset" => Color::Reset,
+        "black" => Color::Black,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "magenta" => Color::Magenta,
+        "cyan" => Color::Cyan,
+        "gray" | "grey" => Color::Gray,
+        "darkgray" | "darkgrey" => Color::DarkGray,
+        "lightred" => Color::LightRed,
+        "lightgreen" => Color::LightGreen,
+        "lightyellow" => Color::LightYellow,
+        "lightblue" => Color::LightBlue,
+        "lightmagenta" => Color::LightMagenta,
+        "lightcyan" => Color::LightCyan,
+        "white" => Color::White,
+        _ if normalized.starts_with('#') => return parse_hex_color(&normalized),
+        _ => bail!("unknown color value '{value}'"),
+    };
+
+    Ok(color)
+}
+
+fn parse_hex_color(value: &str) -> Result<Color> {
+    if value.len() != 7 {
+        bail!("hex colors must use #RRGGBB format, got '{value}'");
+    }
+
+    let r = u8::from_str_radix(&value[1..3], 16)
+        .with_context(|| format!("invalid red component in '{value}'"))?;
+    let g = u8::from_str_radix(&value[3..5], 16)
+        .with_context(|| format!("invalid green component in '{value}'"))?;
+    let b = u8::from_str_radix(&value[5..7], 16)
+        .with_context(|| format!("invalid blue component in '{value}'"))?;
+
+    Ok(Color::Rgb(r, g, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::Path,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    fn temp_file_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("bluetui-{name}-{nanos}.toml"))
+    }
+
+    #[test]
+    fn load_missing_theme_file_falls_back_to_default() {
+        let theme = Theme::load(Some(Path::new(
+            "/tmp/bluetui-definitely-missing-theme.toml",
+        )))
+        .unwrap();
+
+        assert_eq!(theme.selected_row.bg, Some(Color::DarkGray));
+        assert_eq!(theme.selected_row.fg, Some(Color::White));
+    }
+
+    #[test]
+    fn load_theme_file_applies_partial_overrides() {
+        let path = temp_file_path("theme");
+        fs::write(
+            &path,
+            r##"
+[selected_row]
+fg = "#111111"
+bg = "#eeeeee"
+modifiers = ["bold"]
+
+[focused_border]
+fg = "blue"
+"##,
+        )
+        .unwrap();
+
+        let theme = Theme::load(Some(&path)).unwrap();
+
+        assert_eq!(theme.selected_row.fg, Some(Color::Rgb(0x11, 0x11, 0x11)));
+        assert_eq!(theme.selected_row.bg, Some(Color::Rgb(0xee, 0xee, 0xee)));
+        assert!(theme.selected_row.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(theme.focused_border.fg, Some(Color::Blue));
+        assert_eq!(theme.popup_border.fg, Some(Color::Green));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_theme_file_returns_error() {
+        let path = temp_file_path("invalid-theme");
+        fs::write(
+            &path,
+            r#"
+[selected_row]
+fg = "not-a-color"
+"#,
+        )
+        .unwrap();
+
+        let err = Theme::load(Some(&path)).unwrap_err().to_string();
+        assert!(err.contains("failed to parse theme file"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_modifier_returns_error() {
+        let path = temp_file_path("invalid-modifier");
+        fs::write(
+            &path,
+            r#"
+[header]
+modifiers = ["flashy"]
+"#,
+        )
+        .unwrap();
+
+        let err = Theme::load(Some(&path)).unwrap_err().to_string();
+        assert!(err.contains("failed to parse theme file"));
+
+        let _ = fs::remove_file(path);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,6 +6,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
     app.render(frame);
 
     for (index, notification) in app.notifications.iter().enumerate() {
-        notification.render(index, frame, app.area(frame));
+        notification.render(index, frame, app.area(frame), &app.theme);
     }
 }


### PR DESCRIPTION
## Summary
- add generic TOML-based `theme_file` support
- introduce a semantic theme layer with defaults matching current UI behavior
- route app, notification, and popup/request rendering through theme styles
- resolve theme paths with `~` expansion and config-relative resolution

## Testing
- cargo test --quiet
