### PR TITLE
chore: use less dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,6 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1", features = ["full"] }
 dirs = "6"
 toml = "0.9"
 serde = { version = "1", features = ["derive"] }
-clap = { version = "4", features = ["derive", "cargo"] }
+clap = { version = "4", features = ["derive"] }
 tui-input = "0.15"
 anyhow = "1"
 libdbus-sys = { version = "0.2", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/pythops/bluetui"
 
 [dependencies]
 async-channel = "2"
-bluer = { version = "0.17", features = ["full"] }
+bluer = { version = "0.17", features = ["bluetoothd"] }
 crossterm = { version = "0.29", default-features = false, features = [
     "event-stream",
 ] }

--- a/src/favorite.rs
+++ b/src/favorite.rs
@@ -1,14 +1,13 @@
 use crate::app::AppResult;
 use anyhow::Context;
 use bluer::Address;
-use clap::crate_name;
 use std::str::FromStr;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 pub async fn read_favorite_devices_from_disk() -> AppResult<Vec<Address>> {
     let data_dir = dirs::data_dir()
         .context("unable to find data_dir")?
-        .join(crate_name!());
+        .join("bluetui");
 
     let file = tokio::fs::File::open(data_dir.join("favorites.txt"))
         .await
@@ -30,7 +29,7 @@ pub async fn read_favorite_devices_from_disk() -> AppResult<Vec<Address>> {
 pub fn save_favorite_devices_to_disk(favorite_devices: &[Address]) -> AppResult<()> {
     let data_dir = dirs::data_dir()
         .context("unable to find data_dir")?
-        .join(crate_name!());
+        .join("bluetui");
 
     let file_path = data_dir.join("favorites.txt");
 


### PR DESCRIPTION
- Stop using `clap`:s `cargo` feature.

- Only use `bluetoothd` feature of `bluer`.

This takes a cold debug build on my machine from 23s to 16s, which I see as a win!
