### PR TITLE
Gracefully exit terminal on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,11 @@ async fn main() -> AppResult<()> {
     tui.init()?;
 
     // Run the app, but always restore the terminal afterwards so a failure
-    // does not leave the user's terminal in raw mode.
+    // does not leave the user's terminal in raw mode. Prioritize the run
+    // error so a failing exit() does not mask the real cause.
     let result = run(&mut tui, config).await;
-    tui.exit()?;
-    result
+    let exit_result = tui.exit();
+    result.and(exit_result)
 }
 
 async fn run(tui: &mut Tui<CrosstermBackend<io::Stdout>>, config: Arc<Config>) -> AppResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,14 @@ async fn main() -> AppResult<()> {
 
     tui.init()?;
 
+    // Run the app, but always restore the terminal afterwards so a failure
+    // does not leave the user's terminal in raw mode.
+    let result = run(&mut tui, config).await;
+    tui.exit()?;
+    result
+}
+
+async fn run(tui: &mut Tui<CrosstermBackend<io::Stdout>>, config: Arc<Config>) -> AppResult<()> {
     let mut app = App::new(config.clone(), tui.events.sender.clone()).await?;
 
     while app.running {
@@ -145,6 +153,5 @@ async fn main() -> AppResult<()> {
         }
     }
 
-    tui.exit()?;
     Ok(())
 }


### PR DESCRIPTION
Related to #118.

Running `bluetui` while the bluetooth service is not running results in the following error:

`Error: internal error: D-Bus error org.freedesktop.DBus.Error.NameHasNoOwner: Could not activate remote peer 'org.bluez': activation request failed: unknown unit`

The side effect of the program exiting is that the terminal is stuck in raw mode and did not get cleaned up. This is true for other runtime errors, i.e., if the bluetooth service is disabled while `bluetui` is running. 

This PR pulls out the running of the application code in a separate function and then performs the terminal cleanup before reporting the result. Note that if both the application and terminal cleanup result in an error, then the application error is prioritized, though this is an unlikely case.

Testing:
1. Running application with bluetooth service disabled and verified terminal is restored
2. Run application with bluetooth service enabled then disabled the service during runtime and verified terminal is restored