### PR TITLE
Some refactoring and clippy fixes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -161,43 +161,43 @@ where
     }
 }
 
-fn default_layout() -> Flex {
+const fn default_layout() -> Flex {
     Flex::SpaceAround
 }
 
-fn default_set_new_name() -> char {
+const fn default_set_new_name() -> char {
     'e'
 }
 
-fn default_toggle_scanning() -> char {
+const fn default_toggle_scanning() -> char {
     's'
 }
 
-fn default_esc_quit() -> bool {
+const fn default_esc_quit() -> bool {
     false
 }
 
-fn default_toggle_adapter_pairing() -> char {
+const fn default_toggle_adapter_pairing() -> char {
     'p'
 }
 
-fn default_toggle_adapter_power() -> char {
+const fn default_toggle_adapter_power() -> char {
     'o'
 }
 
-fn default_toggle_adapter_discovery() -> char {
+const fn default_toggle_adapter_discovery() -> char {
     'd'
 }
 
-fn default_unpair_device() -> char {
+const fn default_unpair_device() -> char {
     'u'
 }
 
-fn default_toggle_device_trust() -> char {
+const fn default_toggle_device_trust() -> char {
     't'
 }
 
-fn default_toggle_device_favorite() -> char {
+const fn default_toggle_device_favorite() -> char {
     'f'
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -14,46 +14,48 @@ use tokio::sync::mpsc::UnboundedSender;
 use tui_input::backend::crossterm::EventHandler;
 
 fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) {
-    if let Some(selected_controller) = app.controller_state.selected() {
-        let controller = &app.controllers[selected_controller];
-        if let Some(index) = app.paired_devices_state.selected() {
-            let addr = controller.paired_devices[index].addr;
-            match controller.adapter.device(addr) {
-                Ok(device) => {
-                    tokio::spawn(async move {
-                        match device.is_connected().await {
-                            Ok(is_connected) => {
-                                if is_connected {
-                                    match device.disconnect().await {
-                                        Ok(()) => {
-                                            let _ = Notification::send(
-                                                "Device disconnected".into(),
-                                                NotificationLevel::Info,
-                                                sender.clone(),
-                                            );
-                                        }
-                                        Err(e) => send_error(e.into(), sender.clone()),
-                                    }
-                                } else {
-                                    match device.connect().await {
-                                        Ok(()) => {
-                                            let _ = Notification::send(
-                                                "Device connected".into(),
-                                                NotificationLevel::Info,
-                                                sender.clone(),
-                                            );
-                                        }
-                                        Err(e) => send_error(e.into(), sender.clone()),
-                                    }
+    let Some(selected_controller) = app.controller_state.selected() else {
+        return;
+    };
+    let Some(index) = app.paired_devices_state.selected() else {
+        return;
+    };
+    let controller = &app.controllers[selected_controller];
+    let addr = controller.paired_devices[index].addr;
+    match controller.adapter.device(addr) {
+        Ok(device) => {
+            tokio::spawn(async move {
+                match device.is_connected().await {
+                    Ok(is_connected) => {
+                        if is_connected {
+                            match device.disconnect().await {
+                                Ok(()) => {
+                                    let _ = Notification::send(
+                                        "Device disconnected".into(),
+                                        NotificationLevel::Info,
+                                        &sender,
+                                    );
                                 }
+                                Err(e) => send_error(e.into(), &sender),
                             }
-                            Err(e) => send_error(e.into(), sender.clone()),
+                        } else {
+                            match device.connect().await {
+                                Ok(()) => {
+                                    let _ = Notification::send(
+                                        "Device connected".into(),
+                                        NotificationLevel::Info,
+                                        &sender,
+                                    );
+                                }
+                                Err(e) => send_error(e.into(), &sender),
+                            }
                         }
-                    });
+                    }
+                    Err(e) => send_error(e.into(), &sender),
                 }
-                Err(e) => send_error(e.into(), sender.clone()),
-            }
+            });
         }
+        Err(e) => send_error(e.into(), &sender),
     }
 }
 
@@ -68,7 +70,7 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                         let _ = Notification::send(
                             format!("Start pairing with the device {device_name}").into(),
                             NotificationLevel::Info,
-                            sender.clone(),
+                            &sender,
                         );
 
                         tokio::spawn(async move {
@@ -77,7 +79,7 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                                     let _ = Notification::send(
                                         "Device paired".into(),
                                         NotificationLevel::Info,
-                                        sender.clone(),
+                                        &sender,
                                     );
 
                                     let _ = sender.send(Event::NewPairedDevice(device.address()));
@@ -86,32 +88,32 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                                             let _ = Notification::send(
                                                 "Device trusted".into(),
                                                 NotificationLevel::Info,
-                                                sender.clone(),
+                                                &sender,
                                             );
                                         }
-                                        Err(e) => send_error(e.into(), sender.clone()),
+                                        Err(e) => send_error(e.into(), &sender),
                                     }
                                     match device.connect().await {
                                         Ok(()) => {
                                             let _ = Notification::send(
                                                 "Device connected".into(),
                                                 NotificationLevel::Info,
-                                                sender.clone(),
+                                                &sender,
                                             );
                                         }
-                                        Err(e) => send_error(e.into(), sender.clone()),
+                                        Err(e) => send_error(e.into(), &sender),
                                     }
                                 }
                                 Err(e) => {
-                                    send_error(e.into(), sender.clone());
+                                    send_error(e.into(), &sender);
                                     let _ = sender.send(Event::FailedPairing(device.address()));
                                 }
                             }
                         });
                     }
-                    Err(e) => send_error(e.into(), sender.clone()),
+                    Err(e) => send_error(e.into(), &sender),
                 },
-                Err(e) => send_error(e.into(), sender.clone()),
+                Err(e) => send_error(e.into(), &sender),
             }
         }
     }
@@ -125,28 +127,27 @@ pub async fn handle_key_events(
 ) -> AppResult<()> {
     match app.focused_block {
         FocusedBlock::SetDeviceAliasBox => match key_event.code {
-            KeyCode::Enter => {
-                if let Some(selected_controller) = app.controller_state.selected() {
+            KeyCode::Enter if let Some(selected_controller) = app.controller_state.selected() => {
+                if let Some(index) = app.paired_devices_state.selected() {
                     let controller = &app.controllers[selected_controller];
-                    if let Some(index) = app.paired_devices_state.selected() {
-                        let device = &controller.paired_devices[index];
-                        match device.set_alias(app.new_alias.value().into()).await {
-                            Ok(()) => {
-                                Notification::send(
-                                    "Set New Alias".into(),
-                                    NotificationLevel::Info,
-                                    sender,
-                                )?;
-                            }
-                            Err(e) => {
-                                Notification::send(e.into(), NotificationLevel::Error, sender)?;
-                            }
+                    let device = &controller.paired_devices[index];
+                    match device.set_alias(app.new_alias.value().into()).await {
+                        Ok(()) => {
+                            Notification::send(
+                                "Set New Alias".into(),
+                                NotificationLevel::Info,
+                                &sender,
+                            )?;
                         }
-                        app.focused_block = FocusedBlock::PairedDevices;
-                        app.new_alias.reset();
+                        Err(e) => {
+                            Notification::send(e.into(), NotificationLevel::Error, &sender)?;
+                        }
                     }
+                    app.focused_block = FocusedBlock::PairedDevices;
+                    app.new_alias.reset();
                 }
             }
+            KeyCode::Enter => {}
 
             KeyCode::Esc => {
                 app.focused_block = FocusedBlock::PairedDevices;
@@ -225,20 +226,20 @@ pub async fn handle_key_events(
                     app.focused_block = FocusedBlock::PairedDevices;
                     return Ok(());
                 }
-                if let Some(selected_controller) = app.controller_state.selected() {
+                if let Some(selected_controller) = app.controller_state.selected()
+                    && let Some(index) = app.paired_devices_state.selected()
+                {
                     let controller = &app.controllers[selected_controller];
-                    if let Some(index) = app.paired_devices_state.selected() {
-                        let addr = controller.paired_devices[index].addr;
-                        match controller.adapter.remove_device(addr).await {
-                            Ok(()) => {
-                                let _ = Notification::send(
-                                    "Device unpaired".into(),
-                                    NotificationLevel::Info,
-                                    sender.clone(),
-                                );
-                            }
-                            Err(e) => send_error(e.into(), sender.clone()),
+                    let addr = controller.paired_devices[index].addr;
+                    match controller.adapter.remove_device(addr).await {
+                        Ok(()) => {
+                            let _ = Notification::send(
+                                "Device unpaired".into(),
+                                NotificationLevel::Info,
+                                &sender,
+                            );
                         }
+                        Err(e) => send_error(e.into(), &sender),
                     }
                 }
             }
@@ -421,7 +422,7 @@ pub async fn handle_key_events(
                             Notification::send(
                                 "Scanning stopped".into(),
                                 NotificationLevel::Info,
-                                sender,
+                                &sender,
                             )?;
 
                             app.spinner.active = false;
@@ -436,7 +437,7 @@ pub async fn handle_key_events(
                                 let _ = Notification::send(
                                     "Scanning started".into(),
                                     NotificationLevel::Info,
-                                    sender.clone(),
+                                    &sender,
                                 );
 
                                 match adapter.discover_devices().await {
@@ -447,7 +448,7 @@ pub async fn handle_key_events(
                                             }
                                         }
                                     }
-                                    Err(e) => send_error(e.into(), sender.clone()),
+                                    Err(e) => send_error(e.into(), &sender),
                                 }
                             });
                         }
@@ -468,73 +469,65 @@ pub async fn handle_key_events(
                                 KeyCode::Enter | KeyCode::Char(' ') => toggle_connect(app, sender),
 
                                 // Trust / Untrust
-                                KeyCode::Char(c) if c == config.paired_device.toggle_trust => {
-                                    if let Some(selected_controller) =
-                                        app.controller_state.selected()
-                                    {
+                                KeyCode::Char(c)
+                                    if c == config.paired_device.toggle_trust
+                                        && let Some(selected_controller) =
+                                            app.controller_state.selected() =>
+                                {
+                                    if let Some(index) = app.paired_devices_state.selected() {
                                         let controller = &app.controllers[selected_controller];
-                                        if let Some(index) = app.paired_devices_state.selected() {
-                                            let addr = controller.paired_devices[index].addr;
-                                            match controller.adapter.device(addr) {
-                                                Ok(device) => {
-                                                    tokio::spawn(async move {
-                                                        match device.is_trusted().await {
-                                                            Ok(is_trusted) => {
-                                                                if is_trusted {
-                                                                    match device
-                                                                        .set_trusted(false)
-                                                                        .await
-                                                                    {
-                                                                        Ok(()) => {
-                                                                            let _ = Notification::send(
-                                                                        "Device untrusted"
-                                                                            .into(),
+                                        let addr = controller.paired_devices[index].addr;
+                                        match controller.adapter.device(addr) {
+                                            Ok(device) => {
+                                                tokio::spawn(async move {
+                                                    match device.is_trusted().await {
+                                                        Ok(is_trusted) => {
+                                                            match device
+                                                                .set_trusted(!is_trusted)
+                                                                .await
+                                                            {
+                                                                Ok(()) => {
+                                                                    let _ = Notification::send(
+                                                                        if is_trusted {
+                                                                            "Device untrusted"
+                                                                                .into()
+                                                                        } else {
+                                                                            "Device trusted".into()
+                                                                        },
                                                                         NotificationLevel::Info,
-                                                                        sender.clone(),
+                                                                        &sender,
                                                                     );
-                                                                        }
-                                                                        Err(e) => send_error(e.into(), sender.clone()),
-                                                                    }
-                                                                } else {
-                                                                    match device
-                                                                        .set_trusted(true)
-                                                                        .await
-                                                                    {
-                                                                        Ok(()) => {
-                                                                            let _ = Notification::send(
-                                                                        "Device trusted"
-                                                                            .into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                        }
-
-                                                                        Err(e) => send_error(e.into(), sender.clone()),
-                                                                    }
+                                                                }
+                                                                Err(e) => {
+                                                                    send_error(e.into(), &sender);
                                                                 }
                                                             }
-                                                            Err(e) => send_error(e.into(), sender.clone()),
                                                         }
-                                                    });
-                                                }
-                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                        Err(e) => {
+                                                            send_error(e.into(), &sender);
+                                                        }
+                                                    }
+                                                });
                                             }
+                                            Err(e) => send_error(e.into(), &sender),
                                         }
                                     }
                                 }
+                                KeyCode::Char(c) if c == config.paired_device.toggle_trust => {}
 
                                 // Favorite / Unfavorite
-                                KeyCode::Char(c) if c == config.paired_device.toggle_favorite => {
-                                    if let Some(selected_controller) =
-                                        app.controller_state.selected()
-                                    {
+                                KeyCode::Char(c)
+                                    if c == config.paired_device.toggle_favorite
+                                        && let Some(selected_controller) =
+                                            app.controller_state.selected() =>
+                                {
+                                    if let Some(index) = app.paired_devices_state.selected() {
                                         let controller = &app.controllers[selected_controller];
-                                        if let Some(index) = app.paired_devices_state.selected() {
-                                            let address = controller.paired_devices[index].addr;
-                                            let _ = sender.send(Event::ToggleFavorite(address));
-                                        }
+                                        let address = controller.paired_devices[index].addr;
+                                        let _ = sender.send(Event::ToggleFavorite(address));
                                     }
                                 }
+                                KeyCode::Char(c) if c == config.paired_device.toggle_favorite => {}
 
                                 KeyCode::Char(c) if c == config.paired_device.rename => {
                                     app.focused_block = FocusedBlock::SetDeviceAliasBox;
@@ -557,32 +550,27 @@ pub async fn handle_key_events(
                                             async move {
                                                 match adapter.is_pairable().await {
                                                     Ok(is_pairable) => {
-                                                        if is_pairable {
-                                                            match adapter.set_pairable(false).await
-                                                            {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
-                                                                        "Adapter unpairable".into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                        match adapter
+                                                            .set_pairable(!is_pairable)
+                                                            .await
+                                                        {
+                                                            Ok(()) => {
+                                                                let _ = Notification::send(
+                                                                    if is_pairable {
+                                                                        "Adapter unpairable".into()
+                                                                    } else {
+                                                                        "Adapter pairable".into()
+                                                                    },
+                                                                    NotificationLevel::Info,
+                                                                    &sender,
+                                                                );
                                                             }
-                                                        } else {
-                                                            match adapter.set_pairable(true).await {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
-                                                                        "Adapter pairable".into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                            Err(e) => {
+                                                                send_error(e.into(), &sender);
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => send_error(e.into(), sender.clone()),
+                                                    Err(e) => send_error(e.into(), &sender),
                                                 }
                                             }
                                         });
@@ -600,32 +588,25 @@ pub async fn handle_key_events(
                                             async move {
                                                 match adapter.is_powered().await {
                                                     Ok(is_powered) => {
-                                                        if is_powered {
-                                                            match adapter.set_powered(false).await {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
-                                                                        "Adapter powered off"
-                                                                            .into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                        match adapter.set_powered(!is_powered).await
+                                                        {
+                                                            Ok(()) => {
+                                                                let _ = Notification::send(
+                                                                    if is_powered {
+                                                                        "Adapter powered off".into()
+                                                                    } else {
+                                                                        "Adapter powered on".into()
+                                                                    },
+                                                                    NotificationLevel::Info,
+                                                                    &sender,
+                                                                );
                                                             }
-                                                        } else {
-                                                            match adapter.set_powered(true).await {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
-                                                                        "Adapter powered on".into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                            Err(e) => {
+                                                                send_error(e.into(), &sender);
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => send_error(e.into(), sender.clone()),
+                                                    Err(e) => send_error(e.into(), &sender),
                                                 }
                                             }
                                         });
@@ -643,39 +624,29 @@ pub async fn handle_key_events(
                                             async move {
                                                 match adapter.is_discoverable().await {
                                                     Ok(is_discoverable) => {
-                                                        if is_discoverable {
-                                                            match adapter
-                                                                .set_discoverable(false)
-                                                                .await
-                                                            {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
+                                                        match adapter
+                                                            .set_discoverable(!is_discoverable)
+                                                            .await
+                                                        {
+                                                            Ok(()) => {
+                                                                let _ = Notification::send(
+                                                                    if is_discoverable {
                                                                         "Adapter undiscoverable"
-                                                                            .into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
-                                                            }
-                                                        } else {
-                                                            match adapter
-                                                                .set_discoverable(true)
-                                                                .await
-                                                            {
-                                                                Ok(()) => {
-                                                                    let _ = Notification::send(
+                                                                            .into()
+                                                                    } else {
                                                                         "Adapter discoverable"
-                                                                            .into(),
-                                                                        NotificationLevel::Info,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
-                                                                Err(e) => send_error(e.into(), sender.clone()),
+                                                                            .into()
+                                                                    },
+                                                                    NotificationLevel::Info,
+                                                                    &sender,
+                                                                );
+                                                            }
+                                                            Err(e) => {
+                                                                send_error(e.into(), &sender);
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => send_error(e.into(), sender.clone()),
+                                                    Err(e) => send_error(e.into(), &sender),
                                                 }
                                             }
                                         });
@@ -704,10 +675,6 @@ pub async fn handle_key_events(
     Ok(())
 }
 
-fn send_error(msg: StringRef, sender: UnboundedSender<Event>) {
-    let _ = Notification::send(
-        msg,
-        NotificationLevel::Error,
-        sender.clone(),
-    );
+fn send_error(msg: StringRef, sender: &UnboundedSender<Event>) {
+    let _ = Notification::send(msg, NotificationLevel::Error, sender);
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,6 +6,7 @@ use crate::app::{App, AppResult};
 use crate::config::Config;
 use crate::event::Event;
 use crate::notification::{Notification, NotificationLevel};
+use crate::string_ref::StringRef;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use futures::StreamExt;
 use tokio::sync::mpsc::UnboundedSender;
@@ -31,13 +32,7 @@ fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) {
                                                 sender.clone(),
                                             );
                                         }
-                                        Err(e) => {
-                                            let _ = Notification::send(
-                                                e.into(),
-                                                NotificationLevel::Error,
-                                                sender.clone(),
-                                            );
-                                        }
+                                        Err(e) => send_error(e.into(), sender.clone()),
                                     }
                                 } else {
                                     match device.connect().await {
@@ -48,29 +43,15 @@ fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) {
                                                 sender.clone(),
                                             );
                                         }
-                                        Err(e) => {
-                                            let _ = Notification::send(
-                                                e.into(),
-                                                NotificationLevel::Error,
-                                                sender.clone(),
-                                            );
-                                        }
+                                        Err(e) => send_error(e.into(), sender.clone()),
                                     }
                                 }
                             }
-                            Err(e) => {
-                                let _ = Notification::send(
-                                    e.into(),
-                                    NotificationLevel::Error,
-                                    sender.clone(),
-                                );
-                            }
+                            Err(e) => send_error(e.into(), sender.clone()),
                         }
                     });
                 }
-                Err(e) => {
-                    let _ = Notification::send(e.into(), NotificationLevel::Error, sender.clone());
-                }
+                Err(e) => send_error(e.into(), sender.clone()),
             }
         }
     }
@@ -108,13 +89,7 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                                                 sender.clone(),
                                             );
                                         }
-                                        Err(e) => {
-                                            let _ = Notification::send(
-                                                e.into(),
-                                                NotificationLevel::Error,
-                                                sender.clone(),
-                                            );
-                                        }
+                                        Err(e) => send_error(e.into(), sender.clone()),
                                     }
                                     match device.connect().await {
                                         Ok(()) => {
@@ -124,34 +99,19 @@ async fn pair(app: &mut App, sender: UnboundedSender<Event>) {
                                                 sender.clone(),
                                             );
                                         }
-                                        Err(e) => {
-                                            let _ = Notification::send(
-                                                e.into(),
-                                                NotificationLevel::Error,
-                                                sender.clone(),
-                                            );
-                                        }
+                                        Err(e) => send_error(e.into(), sender.clone()),
                                     }
                                 }
                                 Err(e) => {
-                                    let _ = Notification::send(
-                                        e.into(),
-                                        NotificationLevel::Error,
-                                        sender.clone(),
-                                    );
+                                    send_error(e.into(), sender.clone());
                                     let _ = sender.send(Event::FailedPairing(device.address()));
                                 }
                             }
                         });
                     }
-                    Err(e) => {
-                        let _ =
-                            Notification::send(e.into(), NotificationLevel::Error, sender.clone());
-                    }
+                    Err(e) => send_error(e.into(), sender.clone()),
                 },
-                Err(e) => {
-                    let _ = Notification::send(e.into(), NotificationLevel::Error, sender.clone());
-                }
+                Err(e) => send_error(e.into(), sender.clone()),
             }
         }
     }
@@ -277,13 +237,7 @@ pub async fn handle_key_events(
                                     sender.clone(),
                                 );
                             }
-                            Err(e) => {
-                                let _ = Notification::send(
-                                    e.into(),
-                                    NotificationLevel::Error,
-                                    sender.clone(),
-                                );
-                            }
+                            Err(e) => send_error(e.into(), sender.clone()),
                         }
                     }
                 }
@@ -493,13 +447,7 @@ pub async fn handle_key_events(
                                             }
                                         }
                                     }
-                                    Err(e) => {
-                                        let _ = Notification::send(
-                                            e.into(),
-                                            NotificationLevel::Error,
-                                            sender.clone(),
-                                        );
-                                    }
+                                    Err(e) => send_error(e.into(), sender.clone()),
                                 }
                             });
                         }
@@ -545,13 +493,7 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                         }
-                                                                        Err(e) => {
-                                                                            let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                        }
+                                                                        Err(e) => send_error(e.into(), sender.clone()),
                                                                     }
                                                                 } else {
                                                                     match device
@@ -567,33 +509,15 @@ pub async fn handle_key_events(
                                                                     );
                                                                         }
 
-                                                                        Err(e) => {
-                                                                            let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                        }
+                                                                        Err(e) => send_error(e.into(), sender.clone()),
                                                                     }
                                                                 }
                                                             }
-                                                            Err(e) => {
-                                                                let _ = Notification::send(
-                                                                    e.into(),
-                                                                    NotificationLevel::Error,
-                                                                    sender.clone(),
-                                                                );
-                                                            }
+                                                            Err(e) => send_error(e.into(), sender.clone()),
                                                         }
                                                     });
                                                 }
-                                                Err(e) => {
-                                                    let _ = Notification::send(
-                                                        e.into(),
-                                                        NotificationLevel::Error,
-                                                        sender.clone(),
-                                                    );
-                                                }
+                                                Err(e) => send_error(e.into(), sender.clone()),
                                             }
                                         }
                                     }
@@ -643,13 +567,7 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         } else {
                                                             match adapter.set_pairable(true).await {
@@ -660,23 +578,11 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => {
-                                                        let _ = Notification::send(
-                                                            e.into(),
-                                                            NotificationLevel::Error,
-                                                            sender.clone(),
-                                                        );
-                                                    }
+                                                    Err(e) => send_error(e.into(), sender.clone()),
                                                 }
                                             }
                                         });
@@ -704,13 +610,7 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         } else {
                                                             match adapter.set_powered(true).await {
@@ -721,23 +621,11 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => {
-                                                        let _ = Notification::send(
-                                                            e.into(),
-                                                            NotificationLevel::Error,
-                                                            sender.clone(),
-                                                        );
-                                                    }
+                                                    Err(e) => send_error(e.into(), sender.clone()),
                                                 }
                                             }
                                         });
@@ -768,13 +656,7 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         } else {
                                                             match adapter
@@ -789,23 +671,11 @@ pub async fn handle_key_events(
                                                                         sender.clone(),
                                                                     );
                                                                 }
-                                                                Err(e) => {
-                                                                    let _ = Notification::send(
-                                                                        e.into(),
-                                                                        NotificationLevel::Error,
-                                                                        sender.clone(),
-                                                                    );
-                                                                }
+                                                                Err(e) => send_error(e.into(), sender.clone()),
                                                             }
                                                         }
                                                     }
-                                                    Err(e) => {
-                                                        let _ = Notification::send(
-                                                            e.into(),
-                                                            NotificationLevel::Error,
-                                                            sender.clone(),
-                                                        );
-                                                    }
+                                                    Err(e) => send_error(e.into(), sender.clone()),
                                                 }
                                             }
                                         });
@@ -832,4 +702,12 @@ pub async fn handle_key_events(
     }
 
     Ok(())
+}
+
+fn send_error(msg: StringRef, sender: UnboundedSender<Event>) {
+    let _ = Notification::send(
+        msg,
+        NotificationLevel::Error,
+        sender.clone(),
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> AppResult<()> {
 
     let config_file_path = args.config_path.map(|config_path| {
         if config_path.exists() {
-            config_path.clone()
+            config_path
         } else {
             eprintln!("Config file not found");
             exit(1);

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -59,7 +59,7 @@ impl Notification {
     pub fn send(
         message: StringRef,
         level: NotificationLevel,
-        sender: UnboundedSender<Event>,
+        sender: &UnboundedSender<Event>,
     ) -> AppResult<()> {
         let notif = Notification {
             message,

--- a/src/requests/confirmation.rs
+++ b/src/requests/confirmation.rs
@@ -19,7 +19,7 @@ pub struct Confirmation {
 }
 
 impl Confirmation {
-    pub fn new(adapter: String, device: Address, passkey: u32) -> Self {
+    pub const fn new(adapter: String, device: Address, passkey: u32) -> Self {
         Self {
             adapter,
             device,
@@ -44,7 +44,7 @@ impl Confirmation {
         Ok(())
     }
 
-    pub fn toggle_select(&mut self) {
+    pub const fn toggle_select(&mut self) {
         self.confirmed = !self.confirmed;
     }
 

--- a/src/requests/display_passkey.rs
+++ b/src/requests/display_passkey.rs
@@ -19,7 +19,7 @@ pub struct DisplayPasskey {
 }
 
 impl DisplayPasskey {
-    pub fn new(adapter: String, device: Address, passkey: u32, entered: u16) -> Self {
+    pub const fn new(adapter: String, device: Address, passkey: u32, entered: u16) -> Self {
         Self {
             adapter,
             device,

--- a/src/requests/display_pin_code.rs
+++ b/src/requests/display_pin_code.rs
@@ -18,7 +18,7 @@ pub struct DisplayPinCode {
 }
 
 impl DisplayPinCode {
-    pub fn new(adapter: String, device: Address, pin_code: String) -> Self {
+    pub const fn new(adapter: String, device: Address, pin_code: String) -> Self {
         Self {
             adapter,
             device,

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -5,7 +5,7 @@ pub enum StringRef {
 }
 
 impl StringRef {
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             StringRef::Owned(s) => s.as_str(),
             StringRef::Static(s) => s,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,7 +15,7 @@ pub struct Tui<B: Backend> {
 }
 
 impl<B: Backend> Tui<B> {
-    pub fn new(terminal: Terminal<B>, events: EventHandler) -> Self {
+    pub const fn new(terminal: Terminal<B>, events: EventHandler) -> Self {
         Self { terminal, events }
     }
 


### PR DESCRIPTION
This is mostly just a refactor to make code in `handler.rs` a little prettier.
The only semantic change should be that sending notifications no longer takes ownership of a sender, eliminating a bunch of needless `clone()` calls.
Also I applied clippy lint that places `const fn` everywhere. Which is mostly just a visual indication of which functions *could* be compile time evaluated, so I prefer that. It doesnt change the compiled binary